### PR TITLE
TheHive5 changed parameter names since API is case-sensitive

### DIFF
--- a/thehive_5.yaml
+++ b/thehive_5.yaml
@@ -7,9 +7,9 @@ info:
   version: "1.0"
   x-logo: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAK4AAACuCAYAAACvDDbuAAAAAXNSR0IArs4c6QAAIABJREFUeF7tXXmcTuUX/z73vvs6iy1KJEthVkWU/MqSFq1IhEIJZSdbkmWsiR/ZRYospSj9iPZEMZslS5KKkDHzvrO+231+n2c0zDXvzLzLve+8l3n/nHnuec45z/eee57znOccgspfqRr4c/dd+khztsXj1JhVvMfsJlTLCVwCeNwuAFZC6a2UEi0huAlAFR9VeYFS/EkIdVBCfuUAGzw4LHBCsiBwBZzA5fAaZ3Zmttl+U8sf832ked0NI9edxGUITPclGmxqVyMCrgVAmxKQ2gS0OgWJpkA1Ahhk1RdBNigyCGgGBTlHQf8g4PYJ8KRYXeojpNn+PFnnVxDx6xa49Ks2Ktzg0uchz+xxCh1A8RClpB0hsITj+lEKOyH0CxB8xmu47XnIy67SMCaPkI2ecORXbp6uO+BmHUisxwmeu0HQEkA8KG4DYJJb0RLTzwFwiIKmEJA9Asd/H9F0/wmJ5whrctcFcCntzNsP/NoegjCR40gcKFFRUD6sV8ZH5giIB4S6BYGmguMmWZreuuN6sMLXLHCzk+OrUk5oTgnagZJHCEFdH7Gg6GGU4iQI3UooviACt9eckPKPogUqhflrDrj00O2mbI92ECh9DgQ1QRXnBkiDM4IcUJwBIe+YeccC0vgwcy+umd81AVx6so0uN9fWUPDQrgBeAhBxzayQNIJkAVjE8WS90Wg9Sup+XSAN2YqjonjgZqfHt6YUgwloCwrUrDhVhv/MBDhDQfYQgnnmmJRvw5/j0jlUJHBZKCvLamvMc3QiCB5X8gJUGO8Umz0CmRRhsx4i//naXWF8BDix4oCbcyAhRhCEQQToRIHqAcpd+RgAApyjwBaO4xaYmianK0kpigHuV1+1USVE2iYSIowAiE5JSg5/XmkBpdzs5EzrpP8oxPqGPXDZMaxd43mMCBgMgjvDHwQK5pDiJ8phnsXJfxzux8thDdx/kuNralV0OSjuA6BVMCSUxLoDBF863KRv1YSUM+HKeFgCN+N4c4s2z/mQh9IkQnBzuCrvWuaLUpziCRnjMGg+i66/1x5usoYdcHMONKkuCKolBGhPAX24Kex64ocA+RTYwXHuF01ND54LJ9nDBrh0X6LarvW0JwJWA4gOJyVV8oIMyqGXxcHvIM32u8JBH2EBXPu+xCpE7Z5AQZ4FEBkOiqnkoYQGMgnoGupSTbY023+hovVT4cC9kBpbS8uRVZSibUUro3L+8jVACHY6BNq7Slza6fJHyzeiwoC7YQP4Dg1i23KEm0ZBE+QTsZKy1BogIMkCFcZuP5a2s0sXVEgie4UB15Ye9yAEvE9IZUKM1MAKBT1KkQUO3a0xqdtCMd/Vc4QcuDQtxpgLrp8AzACgqQihK+eUTANODhhthLCMxKbnSkbVB0IhBS6lIPb0uLnkUuphJWh9WCAFDHFSYJElJnUoIaCh4jdkwL24L9HKqd0TOJDhoRKucp7QaUAAnSO4VJOjmu23hWLWkACXnki02nPciwnI06EQqnKOitEABf3AYlL1J/XkB6/swGWgzckR1lPQDhWjzspZQ6kBArLdZOK6yg1eWYHL3ANeXWlpQwmccJiLgH7gcqn6y+k2yAZcthGzpcfOqvRpwwFKoeeB+bzWmLSRcm3YZAEuC3nZwU0lwODQq6xyxnDRAAXmWSCMkyNUJgtwc9LihlTGacMFPhXKR2Gc1xSb+pbUXEgK3MJj3EZxHQjF5so4rdRLpVh6Tkrw+PYjqdulPB6WFLi21NgOAPmg8hhXsSCThfHC42HQp61xadulmkAy4BZmeRFui5ISZs5l8Fi3JQJHf5dMDVKtS5l0Gtah6NYpC9WjKyS/JSAZWWKOgwqdpMoqk2TFCvNpNZ51SkpNtOeoMHiqBl//rMyiLm3u0GHeWCcsZuWURGApkdTJd5Minzdo4LKbCzlq92wK8kpAr2IFPfTljyq8NAlwuoUK4iC4aTUqDm9PBO6/SznAZRIT0Pkml2pEsDcpggau7UDcQ0TAGiXdXMgvUKFTfy1+/UvZlerr3ajH1sUO6HWKAm8m5fCstWnqZ8G8ukEB99+LjYeUdkds4rxIvLs1JLkgwayNT8/2fMSKSYMzfRobRoMyOM7dOJgLmAEDl10hV+c53gXwaBgppFxWDh7T4dnRbmRli12E1glmdLq/3McrdMCWXcC3ydkiHiLMHNbMUKFJA8X56p+4DNqegV59Dxi4OWnx3SjoCqVdIR+WZMHHX+aAFsscrRapwbZlbkRHhPcnNyNLhQf7qXA+03kZvIQAj91nwptjwq70QZkvObv6TkD6mGJT1gViDQICLqswo+HobqUV60g5ZEaP0QXIK7gSRuI5gqE99RjYQxl1jxe+Z8Lcd/PhEa68eQYdj/dm6BDfWGyNAwFEKJ9hRUecAmkZSMUcv4HLanllazybQNExlEIGO5fNrkGXIWoc+0O8Ibullgrvzaa4oWpYlAsoV8y//1GjxwiC306Lvw4Nauux4S0XrJYr1rhcYuEwgOBzs5N/yt9aZX4D15Ye9wyhWKmkWl7MLVi+0YCkpQWiuyUcRzDhRQt6P6mszc2qDyMxeYkdQjGryxZyzAs69O2cB+Y+KOjnoATPW2NS1/rDs18islKfiZFZPyitamKWnUOXoVocP+UQ6aZdCyOWTlHW57VIgBfGm/HFHvH9xPo3a7FhrgMRFoXFpil+2p8Z0cqfEqd+AdeWGj+ZEDrenzcjHMaOe7Ma1m4TF18xG1R4d4aAuNvCe0NWmv5Sf1Gh56scsnPF/D/zYBVMHXY+HNTuFw+UkinWuJQJvj7kM3AvVQL37FVaUeX9Bw14ZoQDTrf4AmrXB/R445V8aDQKs07/rqzTyWHcWzps2iEOg2lUBGtna5HYRGndU2kBx/HNfa2M7hNwWc+F7KistwH08/WNCIdxBQU8Bk1WY9de8YZFr+Gwa5UKN1RTXOxTpNYz53Ro+5wb+U7xy3d/cw0WTHBBp1NOEs6/gi0zX4wY4EtPCp+Am5kcH6vi6Xal9VzYuVuHwdM8ovCXSkXwWn8znn2MdVBS/m/NxxF4Y3E23MW+KCw8Nm8sj7YtlfVisp4Ubg/pEJmQklbeyvgEXHtq3EdK7G7ToY8Bx06JFy/xdh1WTnPAYvLdGp0+q0PSMoqLNifa32XCM4/kSuZisE/+2q1G7PgxB1FWDcb0I6hVw3fA2XN4PD9Wi/2Hxc80uFmH7SuU5i4AoNhsiUt9ImjgXuojRr8pj1A4/Z9SgplLI7B4ozgfgSMEc1/VodP9vlcLyi/gcV9vDc5euBSRUPEEiyfqcH9L32mUpZtdu43oP6kAbs8lH7xGFS2+XOWE3o/P/JZdRgydXgCh+HEggP6drRj1QhYICVmBGUlgQAi5t7w+bGVaXNaxMdtuex+g5b4BknAsEZGjJzV4fixw5h/xjvvuOCuWTrH7BYpv9kag9zjxcapUWVksS+2R/lqcuCpLbenrFrS723dXhr1cL4y34PtU8Ytas6oKK6cBDesq7FAC5COzxdq9rA6YZQI352B8LPXQbUrr2DjuTSvWbrs6GUWF7ct4VKviXyrjryfNaP9Crii3gb1fE/pb8PxTvoPL2zu5clMEJi8WvxTs8GDHUiNuretffPn8BT069PMgK/vq8JgZU4cpKxOOdcAkPHnQ1KR0X7dM4NrT4qaxAxmJDGFIyKQcMqH3WCfsxeKb7ITspa5aDO+Tx5rS+f3rNcpaIivrjiYqLJvsgdXsu69cfGJbNo9+E3j8fFAMNJaltnqm/0BjzsCcFQYsWu8QnahZjCqsmqZBfGNl5GIU01GSJTZ1bGmLVeo6FnYhd2v+VFJD57x8NToPVuPwb+KNSpSVw+b5atSu5Z+1LVLa6XMc2vfhRdEJvZbDqiSKO2MCA+5P6Tx6jyHId1wJZbFowI4VHtSqHlhs+Y/Tejz+igsXbeLnb79Fh43zXDDolZGP8a/es8wq502ldX0vFbj29PhXQWmS3+apgh5g+5J1nxoxccGVjQ5jhWV/TehvRK8nAk/7czg5jJihw6ffiF+IVnEmvDc7MLo9RljwQ6rYCj58rw6zRxdAG8ShyOqPLJi8OFeUPcY2lJMG6dDt4Vxl5TEQMsYSkzLdG6S8Ajc7Ob4q5en3ABpUEA79nrbAQfD4IB2OnBTnI9wVa8a7M7Oh4gOzYkWMfLLTiGEz8lEsrwU8T7B+thmJTf3zdfcfiEDXEdnw/BtJYHNwBHhztB6Ptg0uWuH2cOg5yowf08Q+cqO6WmxeUACdVlERhmPEQ+42J6T8czUgvALXnhr7MDiyDhQmvxFUQQ/MXx2NuWvEWV5mA4/lU9jnPPh8hMIIwIsanDgttrr3JOixbEq+z1aSWe9+4/X4LlnsttSrpcPWJSwMFjyvP6Wr0Hc8QXae2I0Z3D0SQ57LqKAVCmBaghwItJslLu1Tn4BrS4udRxR0a3f/QSN6vuoU+aBM0Ifv1WPWqHzotMFZ2yKl7UmxoOeruXAVs5RWE49lk3nc0dS3Q4OfD+jQb4IHtpwroFLzBO9ON6JFfGBux9WLWuDgMGSqDtt3i3nSqjm8P4vlMQRn1QOAYMCPUND51ti0EjXoSlhcSjvz9rTjxwlB3YBnC+GD7ORp5Ew1tnwt3njotBx2Ltei1g3SLtKjA0xIP3blREqr4TBvDIcO9/gWK93+nQaDkwQ4iuUXxDQw4JO3pd31n/7biLZ9HSgotvljy9KpjRqzRrkkO/mTe6kpxUlLbP36hGwUfT5KANeWHt+RUFohnVQCUcJ3PxsxcIoT2blX5GLhrzF9jejbRRoLVpyvjZ8bMH6+E07XJSvOgvyrphHUryv2rUuT5fhJLXqPpZcPRzRqDlNe0aBzR+mPZ5dvsCBpea4oPGY28lg4XoN77pD2hQ5k7Xx9hhLyoDUm5fPi40sCNzV2DyGkua9EK3pc++fNOP6HeBFur6fDqmkuVI2WPvzDohdzV1bBum05qBatweSXVUhoetEvNSQfiMKE/7pxPsOJbg+aMPT5C7Ls9v/JUKP3WDUOnxC7DPVrG7FjpX8HHH4JKPFgSulea1xai1KBm3UgsR5PPYcohVbiuWUht+QDM6YvL2k5Zg43oHNHaT+95QmQ9osBe9Iovt6rxom/nLhoc4FSikiLGjfW0KJVvBOtEjjc0dQBtTqw2G95PHj7/8bPTRg1p6Q1f7WvES8+rQzwEgKHh/CNI5ruP1Eko8ji2tPiehGQFRSUD0RJoXzmxCkNnh9H8MdZsVVt1tiC92fZQ+bDFTh4zH/XgLXbCpCdK4g+yyILQQCjnke7FlpMGpwPszE04GV7gO4jLdh3SOw21a6hxsqpFPVu9s03D+XaXj0XAfFQ0D6W2FTWoLzwdxm4hcni0VkLQfFCRTLp69wzl5qxZGOeKCMq0qLCullqNKwXGv/t1Gk1piwyYuce/3zpBjcbMXdMHhrdIoDj5I+rHj1hRLeRLmTar4TaWKbci50NGPWCMqwuCJaaMyIGFiWZXwHukVbmbGfuLlDc4St4Kmpc6mErnn01DznF4pQsOaXfU2qM7ucAx8nP2Znzagyeqsa+Q76Fwa7m6Mbqarw5msMdMYEdQ/sjocDKwy/TYtkm5r5cedJk4LFmugFxt/ufG+HP/JKMJfjZrDHeTxr9UPimXQZu7pH4mh4HPQqE96EDi1E+P9aAH9PEfluEmcf6N9VoUFf63fnVivd4CIZPt+CTr4KzVszyrnszH1HW4A8dygPHsZMGdB3mQla22EW5K9aAldPyJIt1l8dHEP/P4bWkobFRyhkRcO3psc+BElYvIax/H+3QY+xcJxwu8Sd2/AsR6NPFv919oIJ+uN2K0XNyRPkAgdLq0NKA/07ID8mGbcWGKExZKj6e1qoJpg3V4In28lv+QHV0+TlCn7fEpL0jBm5a7CaAPBk0cRkJCALBky+bkXpUHDFodrsJG+f752cGyubFTC06DfTg9HlpTuPYhu3t11RofUdogNP5FQv2HRbrL66hCR/+Nzsk/nager/0HP3QEpv21GXgsrJKdpXnb0JgCY6wvE8vXReBpBVigBp0HOa+qkb7u0Oz8N/+rMOANzzIzZcmKsB8896PGvDaoNCE73Z8r8fQ6S7kFYhfvBG9LBj4rH/JQvKudknqlMJucfM3sHJNhT5uVlpMAgduf6gZ8We+o7+Z8PCAfNFtVvZ8ixg11sxyQsXLvztn872/lWDCPGnbhN9W14hty4Lzl33VpdtD8OxIDfaki8OILPXx00V6NLwlNC+Qr/xePU6AkBgRm55cCFx7WnwfgC4PlJjcz7lcBBPma7H+c3HM0WJSYcMcDRrWC52y39vCeAnkHkXpWjIZVDiwJXTx1KMnTOgy3Al7jnhT2LWjBpNfYQckoTECgeGG9LXEpqwoXAFbWuwiAtI/MELyP3X0Nx06D/GUSNMb2duIAT1CY6mKpJQDuKz6zNH/SeN6+Loab79nxqxV4ng3SwPd+BaPhrcEFuLzde5gxlHQxdbYtJfIn7vv0luN+ZsAPBgMQTmf7TkyCt+liP2vhnW0WDHFjVo1pM9HKEuWT3apMXKWANdVJZ2Ckf+WWnrsWh2aQ5MiPk+fVaPPeBWO/i5ODronPgLvzgpNdCZAnW2z5eqfIqyPAxX4zyhIYoCEZH+sQx8zjp0SL+zd8RosmuSGySB/DLS4gCf/1KLnaIq/zkszL7tFMbSnGgO7h9bKuVw8Bk9V4fPvxS8+iy1vXxHar5g/ACKg+wnneYjY9ifcSlTCFwDq+EMglGOnLqqCFR9dvOrUR4Xlkymax4bW4jK5d3wXhWEz7YU786tqcPilFgba+IYqLJxIUC06tMA9cExTeFmTJQMV/ViEo88TURj3kriypV9CyT/4d+rm2pHMlLg4nse3oDDLP2dgM2TaOTwzTIMjv4s3ME1v1WP9WxXTLmlvmgHLN/LYnSouze+rhA3r6PBUB4oenVzQaaWx3r7OzcYNm2bC5i/Fp4x1amqxab4D0RHSxKj94cfnsQTZHg9aE1taTAsC7kefH6ygge9vNWL8vJKx2gFPR2Bk34rxyVgOgC1HhSXrovDtvgL8crLs6Ea1SC2axxjR/WEPEmMywfPFztxDqNfvf45Cz7FZJb4WY/pp8ULX0MTDgxGXQriLZKfEDaAcFgZDKBTPOpw8ug01IOWo2NetGsljdRKH22717QaCnLxm2TU4fVaLjCyCrGJu4i03UlSv6kDVqNCFvEqTM9OmQp9xKqQcEfNSq5oWG9+iiii9SgQMJNnpcQsoxUA5F1Qq2hdtKtzfm0dWttgve7KdGbNGKSDDSSpFBEHnox2Gf3M9xO7A+9OtaNlMGb0wCMFCYkuPW0MoegShi5A+OmOpCUs35YsSttUqgtVJetwVH7qDiJAKLdFkThePxwfqcfg3sW/bvqUBS95Qju4owXvEnhb7I0BE93kk0pMsZM6c16DrEBaOEgfsa1XTYP2b8Ku2rCwMhjHRue9EYMHabFHyPcv1mD9Wg/tbyp8OKp1q6B5iS41LJgTx0hGVn9InO6MwcrZNdAjAKsEM7cXioQ5ZLh7KL5W8M5z6S4eO/V3ILxAf597bTIdV05UEWrBNZQqxp8Wx8jZV5FWb9NSHTjPj4y/FG7Ua0WpsXkBRo2rFb4KklzhwiizxfepiPVZ9XCCKJERZ1PhwPkGdG0MbQw5ckstPXmDADeeMilJlPHhcW1i8+Z9M8QFEy7gIrJmVCS5EVbgFSkAFgPcxO42BiB1aFIbCQsQji4Pf10st3tSyiuVdLRjVL7xTGUsDgGKB6/FwSFpiwIqPSn7m5ozS44n28p39FxSokHxYi1NnXDhyQgWtxoCxPp42bfrciPX/49G0vgtNGgho2oBH/TryfaqdTh79xptK1Pe9+QYVVk0H6tRS5tdJscBlb6LDwaFjPwNOnhEvfKM6Orwz3YkaVaQ9kcrI1GPZBiO2fmNDpp3C6aKgAsUbLxN07+Rbdte+g3r0He8urB3GoiEGHUHT+jo897gO97WU/qh1yy4LhkwXd4tnuhvZ24qXumcqdj+gaOCyBfhytxmDpxeIbvyymrivdDfilV7BX+f5+x8N0o9QbNpuwK692SVOm6Ks7ACER5MGvvmJLCTVfQS7HVzS0jWso0f3hwU0jxVQr7bTZ/ejtM9plp3HgNc1+DFdfDhT70YdtixSXKFnkZiKBy679Tt6tg5bvhIDh1X3Xj9HjyYNAwNvdo4GSz4wYOeefJw87blcK+xqkNzbTI/lU/P8uoGxZWc0Bk/3Huxndc+qR/G4J1GLIT09uKF64G7E1l0WDJ+VK4q+sIqNK6ZwaJWoTBehSP+KBy4T5OBRE7oMcyDfIf5c35OgxpI3XNDrfE8aYfW2vtvHY8ZyivNXbfyuBi277rJwvBnt7/F/g9O6uwF/nivbSrOLlP2e1OOpjvm4oarbr8uMObkqdOynwV/nxXO0aabD/AmOkFXSkSCC4JXENQFcJtmqD62YtEicR8r6NCx7A2iVWL6vy24Qb/qfEe9tFXDkpBMud/lgZ7djNy/0btH/ydAVKrxqKemKS9ebkLSsfGvK3J46NTV4vC2P/t1yfXYfFq+zYMaKkqdhq6cZ0PpO5ZySXXNRhasFcjgJeowwYd9hcTRhRG8TBvYo3V1gGV5nzmkxaLIOacd8T6BmuatJQ/To+pD36MWMpRHId1BMHGTzugE6/OulfNirw3llWagGtY1IGgbE3c6ukpdty7oN57CnWGNRdkerQ6tILJqkoIrkZYh4zVhcFhv97Gsjhs8sKNztsx8r7sws7t2lWFybXYM1W3is2SLg/EX/EtJrVVNjdZL3onEZmWo8O4qAWfHVMyiqVynpT+bl8xgwSYVv9vk3b6RZhR6dCHo8QlCtSumuxuwVFixcd8Wy1qqqxQdvUtx4g2+bSLk+8VLRvWaAyxTCGossW1cdc9dkwOES0L9LJAb3yoJOWzJUdeIPLV6ezOPI7+LTJF8V++h9Kswd4/RqTb/eq8JLky5RWjQRaNPcu6vywaeRGPOW/1ltzNrfWF2DZZMpGpZSUJoddLwyORpf/pQFnZrD5CFqPPwf+WLbvupNqnGKPfINVAF5+Sp8/o0as1ZSnLsY+M567Uwj7krw7loMT7Lgo12XrN1Drc1Y8Jp3cLKGKG16qnA+QD6irGoM6KrCkw84EGEp348PVGdh+NwFRSbZBKPIMbMt2Lwrt0TtMX9oxjQwY/MCu9ddfpZdh9Y9BGTnXQIS6xGx5wMVIizeP9EL3o3GnHcDz4NljU/a3mXE268HFvbzR+5wGftvko2y0hoDUR7zf0+d4TE0yYTUI75vwLzNxXb5b44yoVNb71b0tXnRWLNVDMRnH4nEG4O9b4rOnOPQaYAaGcUuLQYiY6O6RswZ5Sq8CRKqHIhA+JTome8Vl0geiOA/p1vx+kIHDp8I3DUomrd+bR3WznGgSmRJv/nv8zo8NsiD8xfF/6sWxePjBbzXazGs79mQaWr876pr4oHIWbemCknDdGged41bX4JVirq64+9isl39nhQz+k7IQ36x9kz+0ik+/rnHNBg3wAHeSyXxSyVQXYUbw+I/lpMwY7gGj7fzfhGxtD4NgfCp13BYOsmAFgmsm6YiE//KFbvw6o5SLkuWK42XAd/+ZMK4t5ySFe9gU7w/w4CWid4D+Ed+UyP9KDseLgmYJvU5xN3mPRHnYpYGbXrisl8ciKzFn4m2qjCstw7PPHJtWt7Cy5JKuZ7uz2Iy2KQcjESPUdmSWVo2/y03GrBrlTynTtMW18CyTef9EbPcsUmDo9D1kQtXys6X+4QyBhReT1dCQRB/1fnDPgNGzHLjbIZ0ISK2KXtnqgH33BHc5q40Wc6c1eP+Pq4SnSD9lb34+BrRKiQNVaNNi2snfovLBUEUUILJn8W7mKXDEy8TnPpb2joLDW424LOlOVDJ1EjLIxD0HGnG7jRpLXqUhccXK3lERVwbJ2YALpVgUkLRO1+Be/YfFZ4bw0o1SbtI7KRqSA8tXu6ZL2vi9Tsf6jB1iUuS3hLFdXZzTS3emSqg7k3Svsy+rouU4y4XvVNCmVFfBHe7CcbNNWHjjtygCtF5m4td4V4+WYO74svP5vKF19LGHD9pwFNDWcHl8jPT/JmHvXgPtDJi3ricMC/a7JNUl8qMsqHhXtjZF3G27rRi+KwcuDzSh4Bi6mvwySLvVpzdaMjL96+xmkEvQFNKW9R+483YuUcen/SNgRF45tFMr6E8X3QcDmMuF3a+BNy4AQThXz+sNMWlHjag91h2j0u6zVjxuZZMtJSaLD5jqRX7vVzDKWuR29ypw4Du3o9503+x4KkhubK8gCwxfeEEDe69U54XIzTALlZKXwnNS0pTSn4Bj2HTNPjfbnn8t7q19PiylGrhFy6yvAS33yE3Vs9g7wYnVCrvX4cnBlmQckTaTVqR/lrGabF4kgtmozwvudzgFTUvUUq7KG9K2bnbiMHTnMgr8O2WrT+KZSGw4c9p8VI3777tgjVmzAmwBP7M4RZ07uj9ys/6z/QYP98Jtwxuj0bNYdoQHZ7sIM+L4Y9+/R1bol0UI2BXQIM+b4J27GvGkd/l+fRViWAdxgmaNizp37KSos+NIUg96l8i+GXLF8/jnWnefd3jv+vQewzFmX8Co10eIKpFabBjOYXVIs9Xqrz5A///VQ36GKHs1NgXKSGLAyca+ic3fGbF6LnyHAgwaVonagovW3pLRE8+rMJzY7kSLZd81ULVSDXemUbRuH7JxB+3m8PgKTps+17asF5x3vp3MWH0Cwo7EvbWEjXvQJOb3ILqcLg3oS5SfkamBs+P45B+LPiMr9LANndUBB5r773aeV4+8Ne50mGacsiK7BxVqQMIIXigtR21anjnf/f+CHQfLR+w6tfWFFr80ub39QUM4TjvTajpkVbmbGfuLlDcEUJmAp5qd7IWL74uiAqBBEzMy4OHdxvhAAAN8klEQVR1aurx1bvyuCC+8vlIfzMO/ioPD8zXXTCeQ7tW8r34vsrp47i9Dm1+u6qNjhZ+Yi+3SKRftVHlRGctpBQv+EioQodNXmjFys3yuQnj+pnRt6v/98GkVMpHO0wYNTtf8pO0Ih57PmLBpMH+14SQUkZfabH4rSWmwSBCNhbuwkW9Pe1pcb0IyAoKKtOJvK9slj/uyZetSP5FHuCyfghrZ7tQu2bFhoz+/FuF7iNV+POsPFYx4TYzPvxvxb6c5a80AynxUNA+ltjU1UXjRcDNOpBYj6eeQ5RC6wvBihxzbw8j/jgrT4eYx+7XYPpwJ7QaaY9e/dUXaxj92jwd1m2TZ/dfu4Ye37wnjyvir6xljScEDg/hG0c03X/CK3DZH22psXsIIc2lnFgOWnICd9kkC9q2Co9P6O79VnQfLc+XRSnApZTutcalido9lGgDbkuP70go3SYH2KSkeX8vE347LX3SS+NbjPh0qTxACVT+JwZakXJpTyLpTzHAJeRBa0zK58WFLwFcSjvz9rTjxwlBXUm1JDGxHiMi8UOq9P7Zyjcs+E9L79Z2zvKqOPirPLHV8f0J6tXxHv5KOWTEE4Old4taxVrx3pzAr8ZLvKReyVGKk5bY+vWLNmWlugqF7kJa7DwC8kooGAt0jiUfmDBjRZ6kKYxNbtXjg7n5MOpL+rZ//q3Dfb3ZMWygHJf93AMtI7HoDe9X2Fn22TMj9Eg7Ki14Bz5twoi+8sWKpdAUBZ1vjU0bfDWtEhaXDbCnxj4MjqwDhUmKyeWgkXaEHUAAF23S7PxZ155hvbUY8Iz3ZPGVH2oxZbFL0heluF5YZcnPl6pxc62S4GR1IRa8r8Xc1dLNz+oHL5lEcHc418klyIFAu1ni0j71CbjZyfFVKU+/B9BADtBJQdPlYseiWnz+gzQ77iirCh/NV+HmWiX95vwCDi++psd3ydJaPJHPRoDXB+rQ8zHvfvvBowY8M9KF7DxpTH5cQw2WTxUQHSFPqE2KNQZwjHjI3eaEFNYZSvTzanELrW56/KugNEkiBmQh8+vvWnQZBmTag0tGYWWM5o/T44HW3jOmfv9Li4dfEpCbLw1oSlNGmzt0ePv1Aui13sNwb62Kwrz3pIl2/HesCQ/fF95uAggZY4lJme5NX6UClx663ZTt1vwJIEIW1ElEdNcPZrw8LR/5jsBirix1cVA3I4Y8V/oiph+OwLJNHDKypHFLShPdYuIxc5QNFlPpsvQabcV3ySV7UfiqTuYS9X0yCmP6S98oxVcefByXZVY5byKND3u1JqUCt9DqpsVNAzDGx4kqZBhzGdZtNWDmOw6/LSIrhd+zkx79u7HO5sFZ7VAJf+qMCiNmaLHvUGBuS9cHDBjbP6/MlyNUspQzT5IlNnVsaWPKBG7OwfhY6qHbKFAzTITxygYrtXTspB59xrMcVt98XpNBhVkj1GjXKs/n8vThooMCB8HwpChs353lcx4Du7Yzpm8Euj50odSbF+EiHwHOEJ48aGqSUqymuo8+LhtGT7bRZdtt7wP0iXARqiw+zl3QYtN2Hrt+pDh+yo2cq3xSBtaba/JonQh0foCg7k3SH2CESk8OJ48vvtfjwy/cSDtKvfr5rINP7Rs0aNFUQNeHVIhtlCvr9XrpZCcfmS3W7qTu16UGzcu0uIyR7PT41pTSb6RjSn5KmTYVLtoEZNp4pB+xgFKKxg1yUDXKDauZQ3SE55opxclK8p/LAH45bkDKL1qcPg+oOKBebRQWnr6phgdVowWo+MD2APKvVskZCCH3mmNSvi1r7nKBW+jrpsZ9BILHK0KIyjmvMw1QbLbEpZb7hfcJuJnJ8bEqnm6nQPXrTI2V4oZQAwQ45/aQDpEJpfu2Rez4BFyWZJ4dlfU2gH4hlKPCpxo1Mxobd5R9ls/CSzdU0cFokC6FmYBgeG+g3T1hHmeVfoWWmS9GDCD/+brcuKNPwGX85RxIiBEEz16AXOo8dx38dv2ox4A3XKW2Q5VLBazuwto5HjSsW+76ycVCBdClBRzHNzc1TU73ZXKfgcuI2VLjJxNCx/tC+FoY89dZDXq9qsJvf8mTEVaajpo3Za2gPDCblBFblmKtKSVTrHEpE3yl5Rdwv/qqjSoxMusHENzp6wRKHsdKf059W493Pg4tcMe/aESfztLn34btWlD8tD8zotV/fHAR/PJxiwtsS497hlCsZJ2QwlYREjL26+9GdBrg8LvMUqAsRFk0+H6t06/G2YHOFSbPOSjB89aY1LX+8OOXxWWEWbmmbI1nEyg6+jORksfOXx2F+Wtt8MhQEqm4XtiV8YXjjWjbSvoE+bDVP8HnZif/FGm236/TIL+ByxTwT3J8TQ1HdxOCm8NWIRIylmVX4cXXNPjpoLwuQ8dWOrw5tgC6UrLDJBQpLEhRilNOgbSsmpByxl+GAgIumyQnLb4bBV1BAb2/kypx/Nd7DRg42SVLcT2mj0iLCmtnqdGoXvjfupVi/QiQT0D6mGJT1gVCL2DgZhxvblHnOd4F8GggEyvxmU92mgqrKOb82+5UKhlqRGsxbxzFnTHyWnSp+JWIzicug7ZndP29AQWrAwZuodU90KS6IKgOAYiWSJiwJ7NhmwGvL3QGnP97tYAsB/e/43i0vuO6Am0Gx7kbm5oeLKP6WtlQCAq4jLTtQNxDRMAa9rULe9RJwCCrpLjjBw1mreDw+5nAwcZO3G67RY8hvQS0bRlYbq0E4lQEiUzK4Vlr09TPgpk8aODSfYnqHLV7Ng3zW8HBKMnbs6fPajFlkR7/+yGgLx0eudeE1wYWoEpUWN/5klptIKDzTS7VCNJsf1CnK0EDl0lm35dYhWg86yhFW8klDXOCn35pxRe7HUj+heDshdKriLNQV82qGjRrIuDx+zVomRgY4MNcHWWyRwh2FmjynyiquBiMLJIAlzFwITW2lpZwWyhoQjAMKfFZ1gH9fAaHC5kE+w+acfA4B8e/htRiBBrW9aBlYhYsRhWqRnugViknN1aq9SAgyQ4qdKoSl3ZaCpqSAbfQ302N7QCQDwgJ7wuWUiiukobvGqAUWQB92hqXtt33p2TenBUnv2ED+A6N4joQis0ANFIxWUlH0RpwUoLHtx9J3d6lCyS73y+pxS1Sb05a3BABmFEJXkUDTgrmnRww2hSb+pYUxIrTkAW4NC3GaAc3lQAlaj5JLUAlvfDVAAXmWSCMI7Hpkh8HygJcpkpKQWzpsbM4kOHhq9pKzuTSgAA6xxqTNpIQSN+j9upS+lILcXFfopVXuxcTkKelpl1JL3w1QEA/cLlU/aOa7ZctzU02i1ukVnoi0ZqTI6ynoB3CV9WVnEmlAQKy3WTiupJ68oGW8So7cAvdhkLwuhfTSssrFT7Ckg6ztCaTqr/coA0ZcNlEzG3g1O4JlT5vWGIuaKaYTyu4VJPldA9kjyqUpgW2YbOnx80lwEuVobKgsRIuBJwUWGSJSR0q10bMm6AhcRWKT8xCZbng+lXGecMFd0HxURinNUJYJkfIqyzOQg7cImZs6XEPQsD7lcfDQQGnwh4uPMbl0N0ak1ohHZoqDLiFx8MNYttyhJt2PSbmVBjiJJiYJcwIVBi7/VjaTimPcf1hrcKAW8RkYVYZR1ZdjymR/ixUuIxlqYkOgfaWKssrULkqHLiM8cJ8XrV7AgV59nq5SRHoglXgc5kEdE2BtmC8FPm0wcoRFsAtjPXuS1TbtZ72RABrNHzd3GELdgFD9HwG5dDL4uB3BHtzQSp+wwa4RQL9ewFzCQHaXy9X36VaTKnpsCvkFNjBce4Xg7nYKDVfjF7YAZcxxa6+a/OcD3koTbpeio7IsbjB0GTFOnhCxjgMms8CvUIezPzlPRuWwC1imlXM0aroclDcd73UKitvwULwfwcIvnS4Sd9AKsyEgL/CKcIauP/6vga7xvMYETD4eqkSGarFLzEPxU+UwzyLk//Y31peoeY57IFbpBBW4jQh0jaREGHE9VRcOjSAoAWUcrOTM62T/Cn1GRrevM+iGOBe2byxyujCIAJ0quxJERx0WM8FCmzhOG6Br5XAg5tRuqcVB9xC9+GrNqosq60xz9GJld2AAgQDxWaPQCZF2KyHfOm5EOAssj2mSOAW18alPmwYTEBbhHsHTNlW0UfCrGMjBdlDCOaV10fMR5IVNkzxwC20wCfb6HJzbQ0FD+2KSymTYd04uwJWm7VcX8TxZL3RaD1aVsfGCuAtoCmvCeAWl7yw67tHOwiUPgeCmqAwBaQZpT9EkAOKMyDkHTPvWFBaF3KlinnNAbdoIbKT46tSTmhOCdqBkkcIQV2lLpI/fFOKkyB0K6H4ggjcXnNCyj/+PK+UsdcscEVWmHbm7Qd+bQ9BmMhxJA6UqCiodB31KnC1CYgHhLoFgaaC4yZZmt66g5CNklWMqUDRypz6ugBucQ1kHUisxwmeuyloCwISD6AxoDh3IgfAIQqaQkD2CBz/fUTT/SfCFWRy8HXdAbdIiZR25i8cTTcYYDB7nEIHUDxEKWlHCCxyKDpYmpTCTgj9AgSf8Rpuex7ysqs0jMm7HqyrN91dt8D1pgzWCsumdjXiwMdTCM0ISG0CWp2CRIMgGhTmYAFYzvcvGxQZBDSDgpyjoH8QcPsEeFKsLvWRcD+GlVU3VxGvBG4Z2v5z9136SHO2xePUmAVOMHGcoOMELgE8bhcAK6H0VkqJlhDcBKCKjwt3gVL8SQh1UEJ+5QAbPDgscEKyIHAFnMDl8Bpndma22X5Tyx+vqxr7PuqvcNj/ARnwYk1uulhmAAAAAElFTkSuQmCC
   contact:
-    name: "Azgaviperr"
-    url: https://shuffler.io/creators/azgaviperr
     email: azgaviperr@pm.me
+    name: Azgaviperr
+    url: https://shuffler.io/creators/azgaviperr
   x-categories:
     - Cases
 servers:
@@ -29,17 +29,17 @@ paths:
                 type: string
                 example: |-
                   {
-                    "cortexid": "",
-                    "cortexjobid": "",
-                    "enddate": "",
-                    "objectid": "",
-                    "objecttype": "",
+                    "cortexId": "",
+                    "cortexJobId": "",
+                    "endDate": "",
+                    "objectId": "",
+                    "objectType": "",
                     "operations": "",
                     "report": "",
                     "responderdefinition": "",
-                    "responderid": "",
+                    "responderId": "",
                     "respondername": "",
-                    "startdate": "",
+                    "startDate": "",
                     "status": ""
                   }
       summary: Create an action
@@ -52,11 +52,11 @@ paths:
           required: false
           example: |-
             {
-              "cortexid": "${cortexid}",
-              "objectid": "${objectid}",
-              "objecttype": "${objecttype}",
+              "cortexId": "${cortexId}",
+              "objectId": "${objectId}",
+              "objectType": "${objectType}",
               "parameters": "${parameters}",
-              "responderid": "${responderid}",
+              "responderId": "${responderId}",
               "tlp": "${tlp}"
             }
           schema:
@@ -68,11 +68,11 @@ paths:
           example:
             example: |-
               {
-                "cortexid": "${cortexid}",
-                "objectid": "${objectid}",
-                "objecttype": "${objecttype}",
+                "cortexId": "${cortexId}",
+                "objectId": "${objectId}",
+                "objectType": "${objectType}",
                 "parameters": "${parameters}",
-                "responderid": "${responderid}",
+                "responderId": "${responderId}",
                 "tlp": "${tlp}"
               }
   "/api/connector/cortex/action/{entityType}/{entityId}":
@@ -134,7 +134,7 @@ paths:
                 type: string
                 example: |-
                   {
-                    "analyzerid": "",
+                    "analyzerId": "",
                     "content": "",
                     "id": ""
                   }
@@ -148,7 +148,7 @@ paths:
           required: false
           example: |-
             {
-              "analyzerid": "${analyzerid}",
+              "analyzerId": "${analyzerId}",
               "content": "${content}"
             }
           schema:
@@ -160,7 +160,7 @@ paths:
           example:
             example: |-
               {
-                "analyzerid": "${analyzerid}",
+                "analyzerId": "${analyzerId}",
                 "content": "${content}"
               }
   /api/connector/cortex/analyzer/template/_import:
@@ -242,7 +242,7 @@ paths:
                 type: string
                 example: |-
                   {
-                    "analyzerid": "",
+                    "analyzerId": "",
                     "content": "",
                     "id": ""
                   }
@@ -307,8 +307,8 @@ paths:
                 type: string
                 example: |-
                   {
-                    "cortexids": [],
-                    "datatypelist": [],
+                    "cortexIds": [],
+                    "dataTypelist": [],
                     "description": "",
                     "id": "",
                     "name": "",
@@ -338,13 +338,13 @@ paths:
                   {
                     "_type": "",
                     "analyzerdefinition": "",
-                    "analyzerid": "",
+                    "analyzerId": "",
                     "analyzername": "",
-                    "cortexid": "",
-                    "cortexjobid": "",
-                    "enddate": "",
+                    "cortexId": "",
+                    "cortexJobId": "",
+                    "endDate": "",
                     "id": "",
-                    "startdate": "",
+                    "startDate": "",
                     "status": ""
                   }
       summary: Create Cortex job
@@ -357,9 +357,9 @@ paths:
           required: false
           example: |-
             {
-              "analyzerid": "${analyzerid}",
-              "artifactid": "${artifactid}",
-              "cortexid": "${cortexid}",
+              "analyzerId": "${analyzerId}",
+              "artifactId": "${artifactId}",
+              "cortexId": "${cortexId}",
               "parameters": "${parameters}"
             }
           schema:
@@ -371,9 +371,9 @@ paths:
           example:
             example: |-
               {
-                "analyzerid": "${analyzerid}",
-                "artifactid": "${artifactid}",
-                "cortexid": "${cortexid}",
+                "analyzerId": "${analyzerId}",
+                "artifactId": "${artifactId}",
+                "cortexId": "${cortexId}",
                 "parameters": "${parameters}"
               }
   "/api/connector/cortex/job/{jobId}":
@@ -389,13 +389,13 @@ paths:
                   {
                     "_type": "",
                     "analyzerdefinition": "",
-                    "analyzerid": "",
+                    "analyzerId": "",
                     "analyzername": "",
-                    "cortexid": "",
-                    "cortexjobid": "",
-                    "enddate": "",
+                    "cortexId": "",
+                    "cortexJobId": "",
+                    "endDate": "",
                     "id": "",
-                    "startdate": "",
+                    "startDate": "",
                     "status": ""
                   }
       summary: Get Cortex Job
@@ -776,36 +776,36 @@ paths:
                 type: string
                 example: |-
                   {
-                    "_createdat": 0,
-                    "_createdby": "",
+                    "_createdAt": 0,
+                    "_createdBy": "",
                     "_id": "",
                     "_type": "",
-                    "_updatedat": 0,
-                    "_updatedby": "",
-                    "caseid": "",
-                    "casetemplate": "",
-                    "closeddate": 0,
-                    "customfields": [],
+                    "_updatedAt": 0,
+                    "_updatedBy": "",
+                    "caseId": "",
+                    "caseTemplate": "",
+                    "closedDate": 0,
+                    "customFields": [],
                     "date": 0,
                     "description": "",
-                    "externallink": "",
+                    "externalLink": "",
                     "follow": false,
                     "importeddate": 0,
-                    "inprogressdate": 0,
-                    "newdate": 0,
+                    "inProgressDate": 0,
+                    "newDate": 0,
                     "observablecount": 0,
                     "pap": 0,
                     "severity": 0,
                     "source": "",
-                    "sourceref": "",
+                    "sourceRef": "",
                     "stage": "",
                     "status": "",
                     "summary": "",
                     "tags": [],
-                    "timetoacknowledge": 0,
-                    "timetodetect": 0,
-                    "timetoqualify": 0,
-                    "timetotriage": 0,
+                    "timeToAcknowledge": 0,
+                    "timeToDetect": 0,
+                    "timeToQualify": 0,
+                    "timeToTriage": 0,
                     "title": "",
                     "tlp": 0,
                     "type": ""
@@ -820,16 +820,16 @@ paths:
           required: false
           example: |-
             {
-              "casetemplate": "${casetemplate}",
+              "caseTemplate": "${caseTemplate}",
               "customfieldvalue": "${customfieldvalue}",
               "date": "${date}",
               "description": "${description}",
-              "externallink": "${externallink}",
+              "externalLink": "${externalLink}",
               "flag": "${flag}",
               "pap": "${pap}",
               "severity": "${severity}",
               "source": "${source}",
-              "sourceref": "${sourceref}",
+              "sourceRef": "${sourceRef}",
               "status": "${status}",
               "summary": "${summary}",
               "tags": "${tags}",
@@ -846,16 +846,16 @@ paths:
           example:
             example: |-
               {
-                "casetemplate": "${casetemplate}",
+                "caseTemplate": "${caseTemplate}",
                 "customfieldvalue": "${customfieldvalue}",
                 "date": "${date}",
                 "description": "${description}",
-                "externallink": "${externallink}",
+                "externalLink": "${externalLink}",
                 "flag": "${flag}",
                 "pap": "${pap}",
                 "severity": "${severity}",
                 "source": "${source}",
-                "sourceref": "${sourceref}",
+                "sourceRef": "${sourceRef}",
                 "status": "${status}",
                 "summary": "${summary}",
                 "tags": "${tags}",
@@ -883,17 +883,17 @@ paths:
           required: false
           example: |-
             {
-              "customfields": "${customfields}",
+              "customFields": "${customFields}",
               "date": "${date}",
               "description": "${description}",
-              "externallink": "${externallink}",
+              "externalLink": "${externalLink}",
               "follow": "${follow}",
               "ids": "${ids}",
               "lastsyncdate": "${lastsyncdate}",
               "pap": "${pap}",
               "severity": "${severity}",
               "source": "${source}",
-              "sourceref": "${sourceref}",
+              "sourceRef": "${sourceRef}",
               "status": "${status}",
               "summary": "${summary}",
               "tags": "${tags}",
@@ -910,17 +910,17 @@ paths:
           example:
             example: |-
               {
-                "customfields": "${customfields}",
+                "customFields": "${customFields}",
                 "date": "${date}",
                 "description": "${description}",
-                "externallink": "${externallink}",
+                "externalLink": "${externalLink}",
                 "follow": "${follow}",
                 "ids": "${ids}",
                 "lastsyncdate": "${lastsyncdate}",
                 "pap": "${pap}",
                 "severity": "${severity}",
                 "source": "${source}",
-                "sourceref": "${sourceref}",
+                "sourceRef": "${sourceRef}",
                 "status": "${status}",
                 "summary": "${summary}",
                 "tags": "${tags}",
@@ -972,42 +972,42 @@ paths:
                 type: string
                 example: >-
                   {
-                    "_createdat": 0,
-                    "_createdby": "",
+                    "_createdAt": 0,
+                    "_createdBy": "",
                     "_id": "",
                     "_type": "",
-                    "_updatedat": 0,
-                    "_updatedby": "",
-                    "alertdate": 0,
-                    "alertimporteddate": 0,
-                    "alertinprogressdate": 0,
-                    "alertnewdate": 0,
+                    "_updatedAt": 0,
+                    "_updatedBy": "",
+                    "alertDate": 0,
+                    "alertImportedDate": 0,
+                    "alertInProgressDate": 0,
+                    "alertNewDate": 0,
                     "assignee": "",
-                    "closeddate": 0,
-                    "customfields": [],
+                    "closedDate": 0,
+                    "customFields": [],
                     "description": "",
-                    "enddate": 0,
+                    "endDate": 0,
                     "flag": false,
-                    "handlingduration": 0,
-                    "impactstatus": "",
-                    "inprogressdate": 0,
-                    "newdate": 0,
+                    "handlingDuration": 0,
+                    "impactStatus": "",
+                    "inProgressDate": 0,
+                    "newDate": 0,
                     "number": 0,
                     "pap": 0,
                     "severity": 0,
                     "stage": "The value of the stage depends on the status of the case. Can be one of 'New' 'InProgress' or 'Closed'",
-                    "startdate": 0,
+                    "startDate": 0,
                     "status": "",
                     "summary": "",
                     "tags": [],
-                    "timetoacknowledge": 0,
-                    "timetodetect": 0,
-                    "timetoqualify": 0,
-                    "timetoresolve": 0,
-                    "timetotriage": 0,
+                    "timeToAcknowledge": 0,
+                    "timeToDetect": 0,
+                    "timeToQualify": 0,
+                    "timeToResolve": 0,
+                    "timeToTriage": 0,
                     "title": "",
                     "tlp": 0,
-                    "userpermissions": []
+                    "userPermissions": []
                   }
       summary: Merge bulk Alerts with Case
       operationId: Merge_bulk_Alerts_with_Case
@@ -1019,8 +1019,8 @@ paths:
           required: false
           example: |-
             {
-              "alertids": "${alertids}",
-              "caseid": "${caseid}"
+              "alertIds": "${alertIds}",
+              "caseId": "${caseId}"
             }
           schema:
             type: string
@@ -1031,8 +1031,8 @@ paths:
           example:
             example: |-
               {
-                "alertids": "${alertids}",
-                "caseid": "${caseid}"
+                "alertIds": "${alertIds}",
+                "caseId": "${caseId}"
               }
   "/api/v1/alert/{alertId}":
     delete:
@@ -1065,36 +1065,36 @@ paths:
                 type: string
                 example: |-
                   {
-                    "_createdat": 0,
-                    "_createdby": "",
+                    "_createdAt": 0,
+                    "_createdBy": "",
                     "_id": "",
                     "_type": "",
-                    "_updatedat": 0,
-                    "_updatedby": "",
-                    "caseid": "",
-                    "casetemplate": "",
-                    "closeddate": 0,
-                    "customfields": [],
+                    "_updatedAt": 0,
+                    "_updatedBy": "",
+                    "caseId": "",
+                    "caseTemplate": "",
+                    "closedDate": 0,
+                    "customFields": [],
                     "date": 0,
                     "description": "",
-                    "externallink": "",
+                    "externalLink": "",
                     "follow": false,
                     "importeddate": 0,
-                    "inprogressdate": 0,
-                    "newdate": 0,
+                    "inProgressDate": 0,
+                    "newDate": 0,
                     "observablecount": 0,
                     "pap": 0,
                     "severity": 0,
                     "source": "",
-                    "sourceref": "",
+                    "sourceRef": "",
                     "stage": "",
                     "status": "",
                     "summary": "",
                     "tags": [],
-                    "timetoacknowledge": 0,
-                    "timetodetect": 0,
-                    "timetoqualify": 0,
-                    "timetotriage": 0,
+                    "timeToAcknowledge": 0,
+                    "timeToDetect": 0,
+                    "timeToQualify": 0,
+                    "timeToTriage": 0,
                     "title": "",
                     "tlp": 0,
                     "type": ""
@@ -1135,16 +1135,16 @@ paths:
           required: false
           example: |-
             {
-              "customfields": "${customfields}",
+              "customFields": "${customFields}",
               "date": "${date}",
               "description": "${description}",
-              "externallink": "${externallink}",
+              "externalLink": "${externalLink}",
               "follow": "${follow}",
               "lastsyncdate": "${lastsyncdate}",
               "pap": "${pap}",
               "severity": "${severity}",
               "source": "${source}",
-              "sourceref": "${sourceref}",
+              "sourceRef": "${sourceRef}",
               "status": "${status}",
               "summary": "${summary}",
               "tags": "${tags}",
@@ -1161,16 +1161,16 @@ paths:
           example:
             example: |-
               {
-                "customfields": "${customfields}",
+                "customFields": "${customFields}",
                 "date": "${date}",
                 "description": "${description}",
-                "externallink": "${externallink}",
+                "externalLink": "${externalLink}",
                 "follow": "${follow}",
                 "lastsyncdate": "${lastsyncdate}",
                 "pap": "${pap}",
                 "severity": "${severity}",
                 "source": "${source}",
-                "sourceref": "${sourceref}",
+                "sourceRef": "${sourceRef}",
                 "status": "${status}",
                 "summary": "${summary}",
                 "tags": "${tags}",
@@ -1189,42 +1189,42 @@ paths:
                 type: string
                 example: >-
                   {
-                    "_createdat": 0,
-                    "_createdby": "",
+                    "_createdAt": 0,
+                    "_createdBy": "",
                     "_id": "",
                     "_type": "",
-                    "_updatedat": 0,
-                    "_updatedby": "",
-                    "alertdate": 0,
-                    "alertimporteddate": 0,
-                    "alertinprogressdate": 0,
-                    "alertnewdate": 0,
+                    "_updatedAt": 0,
+                    "_updatedBy": "",
+                    "alertDate": 0,
+                    "alertImportedDate": 0,
+                    "alertInProgressDate": 0,
+                    "alertNewDate": 0,
                     "assignee": "",
-                    "closeddate": 0,
-                    "customfields": [],
+                    "closedDate": 0,
+                    "customFields": [],
                     "description": "",
-                    "enddate": 0,
+                    "endDate": 0,
                     "flag": false,
-                    "handlingduration": 0,
-                    "impactstatus": "",
-                    "inprogressdate": 0,
-                    "newdate": 0,
+                    "handlingDuration": 0,
+                    "impactStatus": "",
+                    "inProgressDate": 0,
+                    "newDate": 0,
                     "number": 0,
                     "pap": 0,
                     "severity": 0,
                     "stage": "The value of the stage depends on the status of the case. Can be one of 'New' 'InProgress' or 'Closed'",
-                    "startdate": 0,
+                    "startDate": 0,
                     "status": "",
                     "summary": "",
                     "tags": [],
-                    "timetoacknowledge": 0,
-                    "timetodetect": 0,
-                    "timetoqualify": 0,
-                    "timetoresolve": 0,
-                    "timetotriage": 0,
+                    "timeToAcknowledge": 0,
+                    "timeToDetect": 0,
+                    "timeToQualify": 0,
+                    "timeToResolve": 0,
+                    "timeToTriage": 0,
                     "title": "",
                     "tlp": 0,
-                    "userpermissions": []
+                    "userPermissions": []
                   }
       summary: Create Case from Alert
       operationId: Create_Case_from_Alert
@@ -1242,10 +1242,10 @@ paths:
           required: false
           example: |-
             {
-              "casetemplate": "${casetemplate}",
-              "observablerule": "${observablerule}",
-              "sharingparameters": "${sharingparameters}",
-              "taskrule": "${taskrule}"
+              "caseTemplate": "${caseTemplate}",
+              "observableRule": "${observableRule}",
+              "sharingParameters": "${sharingParameters}",
+              "taskRule": "${taskRule}"
             }
           schema:
             type: string
@@ -1256,10 +1256,10 @@ paths:
           example:
             example: |-
               {
-                "casetemplate": "${casetemplate}",
-                "observablerule": "${observablerule}",
-                "sharingparameters": "${sharingparameters}",
-                "taskrule": "${taskrule}"
+                "caseTemplate": "${caseTemplate}",
+                "observableRule": "${observableRule}",
+                "sharingParameters": "${sharingParameters}",
+                "taskRule": "${taskRule}"
               }
   "/api/v1/alert/{alertId}/comment":
     post:
@@ -1275,7 +1275,7 @@ paths:
                     "_id": "",
                     "_type": "",
                     "createdat": 0,
-                    "createdby": "",
+                    "createdBy": "",
                     "isedited": false,
                     "message": "",
                     "updatedat": 0
@@ -1353,42 +1353,42 @@ paths:
                 type: string
                 example: >-
                   {
-                    "_createdat": 0,
-                    "_createdby": "",
+                    "_createdAt": 0,
+                    "_createdBy": "",
                     "_id": "",
                     "_type": "",
-                    "_updatedat": 0,
-                    "_updatedby": "",
-                    "alertdate": 0,
-                    "alertimporteddate": 0,
-                    "alertinprogressdate": 0,
-                    "alertnewdate": 0,
+                    "_updatedAt": 0,
+                    "_updatedBy": "",
+                    "alertDate": 0,
+                    "alertImportedDate": 0,
+                    "alertInProgressDate": 0,
+                    "alertNewDate": 0,
                     "assignee": "",
-                    "closeddate": 0,
-                    "customfields": [],
+                    "closedDate": 0,
+                    "customFields": [],
                     "description": "",
-                    "enddate": 0,
+                    "endDate": 0,
                     "flag": false,
-                    "handlingduration": 0,
-                    "impactstatus": "",
-                    "inprogressdate": 0,
-                    "newdate": 0,
+                    "handlingDuration": 0,
+                    "impactStatus": "",
+                    "inProgressDate": 0,
+                    "newDate": 0,
                     "number": 0,
                     "pap": 0,
                     "severity": 0,
                     "stage": "The value of the stage depends on the status of the case. Can be one of 'New' 'InProgress' or 'Closed'",
-                    "startdate": 0,
+                    "startDate": 0,
                     "status": "",
                     "summary": "",
                     "tags": [],
-                    "timetoacknowledge": 0,
-                    "timetodetect": 0,
-                    "timetoqualify": 0,
-                    "timetoresolve": 0,
-                    "timetotriage": 0,
+                    "timeToAcknowledge": 0,
+                    "timeToDetect": 0,
+                    "timeToQualify": 0,
+                    "timeToResolve": 0,
+                    "timeToTriage": 0,
                     "title": "",
                     "tlp": 0,
-                    "userpermissions": []
+                    "userPermissions": []
                   }
       summary: Merge Alert with Case
       operationId: Merge_Alert_with_Case
@@ -1446,18 +1446,18 @@ paths:
           example: |-
             {
               "data": "${data}",
-              "datatype": "${datatype}",
-              "ignoresimilarity": "${ignoresimilarity}",
+              "dataType": "${dataType}",
+              "ignoreSimilarity": "${ignoreSimilarity}",
               "ioc": "${ioc}",
-              "iszip": "${iszip}",
+              "isZip": "${isZip}",
               "message": "${message}",
               "pap": "${pap}",
               "sighted": "${sighted}",
-              "sightedat": "${sightedat}",
-              "startdate": "${startdate}",
+              "sightedAt": "${sightedAt}",
+              "startDate": "${startDate}",
               "tags": "${tags}",
               "tlp": "${tlp}",
-              "zippassword": "${zippassword}"
+              "zipPassword": "${zipPassword}"
             }
           schema:
             type: string
@@ -1469,18 +1469,18 @@ paths:
             example: |-
               {
                 "data": "${data}",
-                "datatype": "${datatype}",
-                "ignoresimilarity": "${ignoresimilarity}",
+                "dataType": "${dataType}",
+                "ignoreSimilarity": "${ignoreSimilarity}",
                 "ioc": "${ioc}",
-                "iszip": "${iszip}",
+                "isZip": "${isZip}",
                 "message": "${message}",
                 "pap": "${pap}",
                 "sighted": "${sighted}",
-                "sightedat": "${sightedat}",
-                "startdate": "${startdate}",
+                "sightedAt": "${sightedAt}",
+                "startDate": "${startDate}",
                 "tags": "${tags}",
                 "tlp": "${tlp}",
-                "zippassword": "${zippassword}"
+                "zipPassword": "${zipPassword}"
               }
   "/api/v1/alert/{alertId}/procedure":
     post:
@@ -1493,14 +1493,14 @@ paths:
                 type: string
                 example: |-
                   {
-                    "_createdat": 0,
-                    "_createdby": "",
+                    "_createdAt": 0,
+                    "_createdBy": "",
                     "_id": "",
-                    "_updatedat": 0,
-                    "_updatedby": "",
+                    "_updatedAt": 0,
+                    "_updatedBy": "",
                     "description": "",
-                    "occurdate": 0,
-                    "patternid": "",
+                    "occurDate": 0,
+                    "patternId": "",
                     "patternname": "",
                     "tactic": "",
                     "tacticlabel": ""
@@ -1522,8 +1522,8 @@ paths:
           example: |-
             {
               "description": "${description}",
-              "occurdate": "${occurdate}",
-              "patternid": "${patternid}",
+              "occurDate": "${occurDate}",
+              "patternId": "${patternId}",
               "tactic": "${tactic}"
             }
           schema:
@@ -1536,8 +1536,8 @@ paths:
             example: |-
               {
                 "description": "${description}",
-                "occurdate": "${occurdate}",
-                "patternid": "${patternid}",
+                "occurDate": "${occurDate}",
+                "patternId": "${patternId}",
                 "tactic": "${tactic}"
               }
   "/api/v1/alert/{alertId}/unfollow":
@@ -1584,12 +1584,12 @@ paths:
                 type: string
                 example: |-
                   {
-                    "_createdat": 0,
-                    "_createdby": "",
+                    "_createdAt": 0,
+                    "_createdBy": "",
                     "_id": "",
                     "_type": "",
-                    "_updatedat": 0,
-                    "_updatedby": "",
+                    "_updatedAt": 0,
+                    "_updatedBy": "",
                     "colour": "",
                     "description": "",
                     "order": 0,
@@ -1909,42 +1909,42 @@ paths:
                 type: string
                 example: >-
                   {
-                    "_createdat": 0,
-                    "_createdby": "",
+                    "_createdAt": 0,
+                    "_createdBy": "",
                     "_id": "",
                     "_type": "",
-                    "_updatedat": 0,
-                    "_updatedby": "",
-                    "alertdate": 0,
-                    "alertimporteddate": 0,
-                    "alertinprogressdate": 0,
-                    "alertnewdate": 0,
+                    "_updatedAt": 0,
+                    "_updatedBy": "",
+                    "alertDate": 0,
+                    "alertImportedDate": 0,
+                    "alertInProgressDate": 0,
+                    "alertNewDate": 0,
                     "assignee": "",
-                    "closeddate": 0,
-                    "customfields": [],
+                    "closedDate": 0,
+                    "customFields": [],
                     "description": "",
-                    "enddate": 0,
+                    "endDate": 0,
                     "flag": false,
-                    "handlingduration": 0,
-                    "impactstatus": "",
-                    "inprogressdate": 0,
-                    "newdate": 0,
+                    "handlingDuration": 0,
+                    "impactStatus": "",
+                    "inProgressDate": 0,
+                    "newDate": 0,
                     "number": 0,
                     "pap": 0,
                     "severity": 0,
                     "stage": "The value of the stage depends on the status of the case. Can be one of 'New' 'InProgress' or 'Closed'",
-                    "startdate": 0,
+                    "startDate": 0,
                     "status": "",
                     "summary": "",
                     "tags": [],
-                    "timetoacknowledge": 0,
-                    "timetodetect": 0,
-                    "timetoqualify": 0,
-                    "timetoresolve": 0,
-                    "timetotriage": 0,
+                    "timeToAcknowledge": 0,
+                    "timeToDetect": 0,
+                    "timeToQualify": 0,
+                    "timeToResolve": 0,
+                    "timeToTriage": 0,
                     "title": "",
                     "tlp": 0,
-                    "userpermissions": []
+                    "userPermissions": []
                   }
       summary: Create case
       operationId: Create_case
@@ -1958,20 +1958,20 @@ paths:
           required: false
           example: |-
             {
-              "casetemplate": "${casetemplate}",
-              "customfields": "${customfields}",
+              "caseTemplate": "${caseTemplate}",
+              "customFields": "${customFields}",
               "description": "${description}",
-              "enddate": "${enddate}",
+              "endDate": "${endDate}",
               "flag": "${flag}",
-              "observablerule": "${observablerule}",
+              "observableRule": "${observableRule}",
               "pap": "${pap}",
               "severity": "${severity}",
-              "sharingparameters": "${sharingparameters}",
-              "startdate": "${startdate}",
+              "sharingParameters": "${sharingParameters}",
+              "startDate": "${startDate}",
               "status": "${status}",
               "summary": "${summary}",
               "tags": "${tags}",
-              "taskrule": "${taskrule}",
+              "taskRule": "${taskRule}",
               "tasks": "${tasks}",
               "title": "${title}",
               "tlp": "${tlp}",
@@ -1986,20 +1986,20 @@ paths:
           example:
             example: |-
               {
-                "casetemplate": "${casetemplate}",
-                "customfields": "${customfields}",
+                "caseTemplate": "${caseTemplate}",
+                "customFields": "${customFields}",
                 "description": "${description}",
-                "enddate": "${enddate}",
+                "endDate": "${endDate}",
                 "flag": "${flag}",
-                "observablerule": "${observablerule}",
+                "observableRule": "${observableRule}",
                 "pap": "${pap}",
                 "severity": "${severity}",
-                "sharingparameters": "${sharingparameters}",
-                "startdate": "${startdate}",
+                "sharingParameters": "${sharingParameters}",
+                "startDate": "${startDate}",
                 "status": "${status}",
                 "summary": "${summary}",
                 "tags": "${tags}",
-                "taskrule": "${taskrule}",
+                "taskRule": "${taskRule}",
                 "tasks": "${tasks}",
                 "title": "${title}",
                 "tlp": "${tlp}",
@@ -2026,20 +2026,20 @@ paths:
           example: |-
             {
               "assignee": "${assignee}",
-              "customfields": "${customfields}",
+              "customFields": "${customFields}",
               "description": "${description}",
-              "enddate": "${enddate}",
+              "endDate": "${endDate}",
               "flag": "${flag}",
               "ids": "${ids}",
-              "impactstatus": "${impactstatus}",
-              "observablerule": "${observablerule}",
+              "impactStatus": "${impactStatus}",
+              "observableRule": "${observableRule}",
               "pap": "${pap}",
               "severity": "${severity}",
-              "startdate": "${startdate}",
+              "startDate": "${startDate}",
               "status": "${status}",
               "summary": "${summary}",
               "tags": "${tags}",
-              "taskrule": "${taskrule}",
+              "taskRule": "${taskRule}",
               "title": "${title}",
               "tlp": "${tlp}"
             }
@@ -2053,20 +2053,20 @@ paths:
             example: |-
               {
                 "assignee": "${assignee}",
-                "customfields": "${customfields}",
+                "customFields": "${customFields}",
                 "description": "${description}",
-                "enddate": "${enddate}",
+                "endDate": "${endDate}",
                 "flag": "${flag}",
                 "ids": "${ids}",
-                "impactstatus": "${impactstatus}",
-                "observablerule": "${observablerule}",
+                "impactStatus": "${impactStatus}",
+                "observableRule": "${observableRule}",
                 "pap": "${pap}",
                 "severity": "${severity}",
-                "startdate": "${startdate}",
+                "startDate": "${startDate}",
                 "status": "${status}",
                 "summary": "${summary}",
                 "tags": "${tags}",
-                "taskrule": "${taskrule}",
+                "taskRule": "${taskRule}",
                 "title": "${title}",
                 "tlp": "${tlp}"
               }
@@ -2081,42 +2081,42 @@ paths:
                 type: string
                 example: >-
                   {
-                    "_createdat": 0,
-                    "_createdby": "",
+                    "_createdAt": 0,
+                    "_createdBy": "",
                     "_id": "",
                     "_type": "",
-                    "_updatedat": 0,
-                    "_updatedby": "",
-                    "alertdate": 0,
-                    "alertimporteddate": 0,
-                    "alertinprogressdate": 0,
-                    "alertnewdate": 0,
+                    "_updatedAt": 0,
+                    "_updatedBy": "",
+                    "alertDate": 0,
+                    "alertImportedDate": 0,
+                    "alertInProgressDate": 0,
+                    "alertNewDate": 0,
                     "assignee": "",
-                    "closeddate": 0,
-                    "customfields": [],
+                    "closedDate": 0,
+                    "customFields": [],
                     "description": "",
-                    "enddate": 0,
+                    "endDate": 0,
                     "flag": false,
-                    "handlingduration": 0,
-                    "impactstatus": "",
-                    "inprogressdate": 0,
-                    "newdate": 0,
+                    "handlingDuration": 0,
+                    "impactStatus": "",
+                    "inProgressDate": 0,
+                    "newDate": 0,
                     "number": 0,
                     "pap": 0,
                     "severity": 0,
                     "stage": "The value of the stage depends on the status of the case. Can be one of 'New' 'InProgress' or 'Closed'",
-                    "startdate": 0,
+                    "startDate": 0,
                     "status": "",
                     "summary": "",
                     "tags": [],
-                    "timetoacknowledge": 0,
-                    "timetodetect": 0,
-                    "timetoqualify": 0,
-                    "timetoresolve": 0,
-                    "timetotriage": 0,
+                    "timeToAcknowledge": 0,
+                    "timeToDetect": 0,
+                    "timeToQualify": 0,
+                    "timeToResolve": 0,
+                    "timeToTriage": 0,
                     "title": "",
                     "tlp": 0,
-                    "userpermissions": []
+                    "userPermissions": []
                   }
       summary: Merge cases
       operationId: Merge_cases
@@ -2275,27 +2275,9 @@ paths:
                 example: ""
       summary: Delete Shares by shareId
       operationId: Delete_Shares_by_shareId
-      parameters:
-        - in: body
-          name: body
-          multiline: true
-          description: Generated by shuffler.io OpenAPI
-          required: false
-          example: |-
-            {
-              "ids": "${ids}"
-            }
-          schema:
-            type: string
+      parameters: []
       requestBody:
-        description: Generated by Shuffler.io
-        required: false
-        content:
-          example:
-            example: |-
-              {
-                "ids": "${ids}"
-              }
+        content: {}
   "/api/v1/case/{caseId}/alert/{alertId}":
     delete:
       responses:
@@ -2461,7 +2443,7 @@ paths:
                     "_id": "",
                     "_type": "",
                     "createdat": 0,
-                    "createdby": "",
+                    "createdBy": "",
                     "isedited": false,
                     "message": "",
                     "updatedat": 0
@@ -2506,15 +2488,15 @@ paths:
                 type: string
                 example: |-
                   {
-                    "_createdat": 0,
-                    "_createdby": "",
+                    "_createdAt": 0,
+                    "_createdBy": "",
                     "_id": "",
                     "_type": "",
-                    "_updatedat": 0,
-                    "_updatedby": "",
+                    "_updatedAt": 0,
+                    "_updatedBy": "",
                     "date": 0,
                     "description": "",
-                    "enddate": 0,
+                    "endDate": 0,
                     "title": ""
                   }
       summary: Create Custom Event
@@ -2535,7 +2517,7 @@ paths:
             {
               "date": "${date}",
               "description": "${description}",
-              "enddate": "${enddate}",
+              "endDate": "${endDate}",
               "title": "${title}"
             }
           schema:
@@ -2549,7 +2531,7 @@ paths:
               {
                 "date": "${date}",
                 "description": "${description}",
-                "enddate": "${enddate}",
+                "endDate": "${endDate}",
                 "title": "${title}"
               }
   "/api/v1/case/{caseId}/export":
@@ -2630,18 +2612,18 @@ paths:
           example: |-
             {
               "data": "${data}",
-              "datatype": "${datatype}",
-              "ignoresimilarity": "${ignoresimilarity}",
+              "dataType": "${dataType}",
+              "ignoreSimilarity": "${ignoreSimilarity}",
               "ioc": "${ioc}",
-              "iszip": "${iszip}",
+              "isZip": "${isZip}",
               "message": "${message}",
               "pap": "${pap}",
               "sighted": "${sighted}",
-              "sightedat": "${sightedat}",
-              "startdate": "${startdate}",
+              "sightedAt": "${sightedAt}",
+              "startDate": "${startDate}",
               "tags": "${tags}",
               "tlp": "${tlp}",
-              "zippassword": "${zippassword}"
+              "zipPassword": "${zipPassword}"
             }
           schema:
             type: string
@@ -2653,18 +2635,18 @@ paths:
             example: |-
               {
                 "data": "${data}",
-                "datatype": "${datatype}",
-                "ignoresimilarity": "${ignoresimilarity}",
+                "dataType": "${dataType}",
+                "ignoreSimilarity": "${ignoreSimilarity}",
                 "ioc": "${ioc}",
-                "iszip": "${iszip}",
+                "isZip": "${isZip}",
                 "message": "${message}",
                 "pap": "${pap}",
                 "sighted": "${sighted}",
-                "sightedat": "${sightedat}",
-                "startdate": "${startdate}",
+                "sightedAt": "${sightedAt}",
+                "startDate": "${startDate}",
                 "tags": "${tags}",
                 "tlp": "${tlp}",
-                "zippassword": "${zippassword}"
+                "zipPassword": "${zipPassword}"
               }
   "/api/v1/case/{caseId}/observable/_merge":
     post:
@@ -2720,7 +2702,7 @@ paths:
                     "category": "",
                     "content": "",
                     "createdat": 0,
-                    "createdby": "",
+                    "createdBy": "",
                     "id": "",
                     "order": 0,
                     "slug": "",
@@ -2851,14 +2833,14 @@ paths:
                 type: string
                 example: |-
                   {
-                    "_createdat": 0,
-                    "_createdby": "",
+                    "_createdAt": 0,
+                    "_createdBy": "",
                     "_id": "",
-                    "_updatedat": 0,
-                    "_updatedby": "",
+                    "_updatedAt": 0,
+                    "_updatedBy": "",
                     "description": "",
-                    "occurdate": 0,
-                    "patternid": "",
+                    "occurDate": 0,
+                    "patternId": "",
                     "patternname": "",
                     "tactic": "",
                     "tacticlabel": ""
@@ -2880,8 +2862,8 @@ paths:
           example: |-
             {
               "description": "${description}",
-              "occurdate": "${occurdate}",
-              "patternid": "${patternid}",
+              "occurDate": "${occurDate}",
+              "patternId": "${patternId}",
               "tactic": "${tactic}"
             }
           schema:
@@ -2894,8 +2876,8 @@ paths:
             example: |-
               {
                 "description": "${description}",
-                "occurdate": "${occurdate}",
-                "patternid": "${patternid}",
+                "occurDate": "${occurDate}",
+                "patternId": "${patternId}",
                 "tactic": "${tactic}"
               }
   "/api/v1/case/{caseId}/shares":
@@ -2917,26 +2899,8 @@ paths:
           required: true
           schema:
             type: string
-        - in: body
-          name: body
-          multiline: true
-          description: Generated by shuffler.io OpenAPI
-          required: false
-          example: |-
-            {
-              "organisations": "${organisations}"
-            }
-          schema:
-            type: string
       requestBody:
-        description: Generated by Shuffler.io
-        required: false
-        content:
-          example:
-            example: |-
-              {
-                "organisations": "${organisations}"
-              }
+        content: {}
     get:
       responses:
         default:
@@ -2969,7 +2933,7 @@ paths:
       summary: Share a Case
       operationId: Share_a_Case
       description: >-
-        Share the case with other organisations. 
+        Share the case with other organisations.
 
         For each organisation, you can define a profile (level of access) that the org will receive
 
@@ -3014,7 +2978,7 @@ paths:
       summary: Set shares for Case
       operationId: Set_shares_for_Case
       description: >-
-        Set the share for a case with other organisations. 
+        Set the share for a case with other organisations.
 
         For each organisation, you can define a profile (level of access) that the org will receive
 
@@ -3058,20 +3022,20 @@ paths:
                 type: string
                 example: |-
                   {
-                    "_createdat": 0,
-                    "_createdby": "",
+                    "_createdAt": 0,
+                    "_createdBy": "",
                     "_id": "",
                     "_type": "",
-                    "_updatedat": 0,
-                    "_updatedby": "",
+                    "_updatedAt": 0,
+                    "_updatedBy": "",
                     "assignee": "",
                     "description": "",
-                    "duedate": 0,
-                    "enddate": 0,
+                    "dueDate": 0,
+                    "endDate": 0,
                     "flag": false,
                     "group": "",
                     "order": 0,
-                    "startdate": 0,
+                    "startDate": 0,
                     "status": "",
                     "title": ""
                   }
@@ -3093,12 +3057,12 @@ paths:
             {
               "assignee": "${assignee}",
               "description": "${description}",
-              "duedate": "${duedate}",
-              "enddate": "${enddate}",
+              "dueDate": "${dueDate}",
+              "endDate": "${endDate}",
               "flag": "${flag}",
               "group": "${group}",
               "order": "${order}",
-              "startdate": "${startdate}",
+              "startDate": "${startDate}",
               "status": "${status}",
               "title": "${title}"
             }
@@ -3113,12 +3077,12 @@ paths:
               {
                 "assignee": "${assignee}",
                 "description": "${description}",
-                "duedate": "${duedate}",
-                "enddate": "${enddate}",
+                "dueDate": "${dueDate}",
+                "endDate": "${endDate}",
                 "flag": "${flag}",
                 "group": "${group}",
                 "order": "${order}",
-                "startdate": "${startdate}",
+                "startDate": "${startDate}",
                 "status": "${status}",
                 "title": "${title}"
               }
@@ -3177,42 +3141,42 @@ paths:
                 type: string
                 example: >-
                   {
-                    "_createdat": 0,
-                    "_createdby": "",
+                    "_createdAt": 0,
+                    "_createdBy": "",
                     "_id": "",
                     "_type": "",
-                    "_updatedat": 0,
-                    "_updatedby": "",
-                    "alertdate": 0,
-                    "alertimporteddate": 0,
-                    "alertinprogressdate": 0,
-                    "alertnewdate": 0,
+                    "_updatedAt": 0,
+                    "_updatedBy": "",
+                    "alertDate": 0,
+                    "alertImportedDate": 0,
+                    "alertInProgressDate": 0,
+                    "alertNewDate": 0,
                     "assignee": "",
-                    "closeddate": 0,
-                    "customfields": [],
+                    "closedDate": 0,
+                    "customFields": [],
                     "description": "",
-                    "enddate": 0,
+                    "endDate": 0,
                     "flag": false,
-                    "handlingduration": 0,
-                    "impactstatus": "",
-                    "inprogressdate": 0,
-                    "newdate": 0,
+                    "handlingDuration": 0,
+                    "impactStatus": "",
+                    "inProgressDate": 0,
+                    "newDate": 0,
                     "number": 0,
                     "pap": 0,
                     "severity": 0,
                     "stage": "The value of the stage depends on the status of the case. Can be one of 'New' 'InProgress' or 'Closed'",
-                    "startdate": 0,
+                    "startDate": 0,
                     "status": "",
                     "summary": "",
                     "tags": [],
-                    "timetoacknowledge": 0,
-                    "timetodetect": 0,
-                    "timetoqualify": 0,
-                    "timetoresolve": 0,
-                    "timetotriage": 0,
+                    "timeToAcknowledge": 0,
+                    "timeToDetect": 0,
+                    "timeToQualify": 0,
+                    "timeToResolve": 0,
+                    "timeToTriage": 0,
                     "title": "",
                     "tlp": 0,
-                    "userpermissions": []
+                    "userPermissions": []
                   }
       summary: Get case
       operationId: Get_case
@@ -3251,19 +3215,19 @@ paths:
           example: |-
             {
               "assignee": "${assignee}",
-              "customfields": "${customfields}",
+              "customFields": "${customFields}",
               "description": "${description}",
-              "enddate": "${enddate}",
+              "endDate": "${endDate}",
               "flag": "${flag}",
-              "impactstatus": "${impactstatus}",
-              "observablerule": "${observablerule}",
+              "impactStatus": "${impactStatus}",
+              "observableRule": "${observableRule}",
               "pap": "${pap}",
               "severity": "${severity}",
-              "startdate": "${startdate}",
+              "startDate": "${startDate}",
               "status": "${status}",
               "summary": "${summary}",
               "tags": "${tags}",
-              "taskrule": "${taskrule}",
+              "taskRule": "${taskRule}",
               "title": "${title}",
               "tlp": "${tlp}"
             }
@@ -3277,19 +3241,19 @@ paths:
             example: |-
               {
                 "assignee": "${assignee}",
-                "customfields": "${customfields}",
+                "customFields": "${customFields}",
                 "description": "${description}",
-                "enddate": "${enddate}",
+                "endDate": "${endDate}",
                 "flag": "${flag}",
-                "impactstatus": "${impactstatus}",
-                "observablerule": "${observablerule}",
+                "impactStatus": "${impactStatus}",
+                "observableRule": "${observableRule}",
                 "pap": "${pap}",
                 "severity": "${severity}",
-                "startdate": "${startdate}",
+                "startDate": "${startDate}",
                 "status": "${status}",
                 "summary": "${summary}",
                 "tags": "${tags}",
-                "taskrule": "${taskrule}",
+                "taskRule": "${taskRule}",
                 "title": "${title}",
                 "tlp": "${tlp}"
               }
@@ -3304,12 +3268,12 @@ paths:
                 type: string
                 example: |-
                   {
-                    "_createdat": 0,
-                    "_createdby": "",
+                    "_createdAt": 0,
+                    "_createdBy": "",
                     "_id": "",
                     "_type": "",
-                    "_updatedat": 0,
-                    "_updatedby": "",
+                    "_updatedAt": 0,
+                    "_updatedBy": "",
                     "colour": "",
                     "description": "",
                     "order": 0,
@@ -3421,15 +3385,15 @@ paths:
                 type: string
                 example: |-
                   {
-                    "_createdat": 0,
-                    "_createdby": "",
+                    "_createdAt": 0,
+                    "_createdBy": "",
                     "_id": "",
                     "_type": "",
-                    "_updatedat": 0,
-                    "_updatedby": "",
-                    "customfields": [],
+                    "_updatedAt": 0,
+                    "_updatedBy": "",
+                    "customFields": [],
                     "description": "",
-                    "displayname": "",
+                    "displayName": "",
                     "flag": false,
                     "name": "",
                     "pap": 0,
@@ -3437,7 +3401,7 @@ paths:
                     "summary": "",
                     "tags": [],
                     "tasks": [],
-                    "titleprefix": "",
+                    "titlePrefix": "",
                     "tlp": 0
                   }
       summary: Create CaseTemplate
@@ -3450,9 +3414,9 @@ paths:
           required: false
           example: |-
             {
-              "customfields": "${customfields}",
+              "customFields": "${customFields}",
               "description": "${description}",
-              "displayname": "${displayname}",
+              "displayName": "${displayName}",
               "flag": "${flag}",
               "name": "${name}",
               "pap": "${pap}",
@@ -3460,7 +3424,7 @@ paths:
               "summary": "${summary}",
               "tags": "${tags}",
               "tasks": "${tasks}",
-              "titleprefix": "${titleprefix}",
+              "titlePrefix": "${titlePrefix}",
               "tlp": "${tlp}"
             }
           schema:
@@ -3472,9 +3436,9 @@ paths:
           example:
             example: |-
               {
-                "customfields": "${customfields}",
+                "customFields": "${customFields}",
                 "description": "${description}",
-                "displayname": "${displayname}",
+                "displayName": "${displayName}",
                 "flag": "${flag}",
                 "name": "${name}",
                 "pap": "${pap}",
@@ -3482,7 +3446,7 @@ paths:
                 "summary": "${summary}",
                 "tags": "${tags}",
                 "tasks": "${tasks}",
-                "titleprefix": "${titleprefix}",
+                "titlePrefix": "${titlePrefix}",
                 "tlp": "${tlp}"
               }
   "/api/v1/caseTemplate/{caseTemplateNameOrId}":
@@ -3516,15 +3480,15 @@ paths:
                 type: string
                 example: |-
                   {
-                    "_createdat": 0,
-                    "_createdby": "",
+                    "_createdAt": 0,
+                    "_createdBy": "",
                     "_id": "",
                     "_type": "",
-                    "_updatedat": 0,
-                    "_updatedby": "",
-                    "customfields": [],
+                    "_updatedAt": 0,
+                    "_updatedBy": "",
+                    "customFields": [],
                     "description": "",
-                    "displayname": "",
+                    "displayName": "",
                     "flag": false,
                     "name": "",
                     "pap": 0,
@@ -3532,7 +3496,7 @@ paths:
                     "summary": "",
                     "tags": [],
                     "tasks": [],
-                    "titleprefix": "",
+                    "titlePrefix": "",
                     "tlp": 0
                   }
       summary: Get CaseTemplate
@@ -3571,9 +3535,9 @@ paths:
           required: false
           example: |-
             {
-              "customfields": "${customfields}",
+              "customFields": "${customFields}",
               "description": "${description}",
-              "displayname": "${displayname}",
+              "displayName": "${displayName}",
               "flag": "${flag}",
               "name": "${name}",
               "pap": "${pap}",
@@ -3581,7 +3545,7 @@ paths:
               "summary": "${summary}",
               "tags": "${tags}",
               "tasks": "${tasks}",
-              "titleprefix": "${titleprefix}",
+              "titlePrefix": "${titlePrefix}",
               "tlp": "${tlp}"
             }
           schema:
@@ -3593,9 +3557,9 @@ paths:
           example:
             example: |-
               {
-                "customfields": "${customfields}",
+                "customFields": "${customFields}",
                 "description": "${description}",
-                "displayname": "${displayname}",
+                "displayName": "${displayName}",
                 "flag": "${flag}",
                 "name": "${name}",
                 "pap": "${pap}",
@@ -3603,7 +3567,7 @@ paths:
                 "summary": "${summary}",
                 "tags": "${tags}",
                 "tasks": "${tasks}",
-                "titleprefix": "${titleprefix}",
+                "titlePrefix": "${titlePrefix}",
                 "tlp": "${tlp}"
               }
   /api/v1/catalog:
@@ -3620,7 +3584,7 @@ paths:
                     "_id": "",
                     "_type": "",
                     "createdat": 0,
-                    "createdby": "",
+                    "createdBy": "",
                     "description": "",
                     "name": "",
                     "updatedat": 0,
@@ -3793,7 +3757,7 @@ paths:
             {
               "date": "${date}",
               "description": "${description}",
-              "enddate": "${enddate}",
+              "endDate": "${endDate}",
               "title": "${title}"
             }
           schema:
@@ -3807,7 +3771,7 @@ paths:
               {
                 "date": "${date}",
                 "description": "${description}",
-                "enddate": "${enddate}",
+                "endDate": "${endDate}",
                 "title": "${title}"
               }
   /api/v1/customField:
@@ -3835,14 +3799,14 @@ paths:
                 type: string
                 example: |-
                   {
-                    "_createdat": 0,
-                    "_createdby": "",
+                    "_createdAt": 0,
+                    "_createdBy": "",
                     "_id": "",
                     "_type": "",
-                    "_updatedat": 0,
-                    "_updatedby": "",
+                    "_updatedAt": 0,
+                    "_updatedBy": "",
                     "description": "",
-                    "displayname": "",
+                    "displayName": "",
                     "group": "",
                     "mandatory": false,
                     "name": "",
@@ -3860,7 +3824,7 @@ paths:
           example: |-
             {
               "description": "${description}",
-              "displayname": "${displayname}",
+              "displayName": "${displayName}",
               "group": "${group}",
               "mandatory": "${mandatory}",
               "name": "${name}",
@@ -3877,7 +3841,7 @@ paths:
             example: |-
               {
                 "description": "${description}",
-                "displayname": "${displayname}",
+                "displayName": "${displayName}",
                 "group": "${group}",
                 "mandatory": "${mandatory}",
                 "name": "${name}",
@@ -3903,26 +3867,8 @@ paths:
           required: true
           schema:
             type: string
-        - in: body
-          name: body
-          multiline: true
-          description: Generated by shuffler.io OpenAPI
-          required: false
-          example: |-
-            {
-              "force": "${force}"
-            }
-          schema:
-            type: string
       requestBody:
-        description: Generated by Shuffler.io
-        required: false
-        content:
-          example:
-            example: |-
-              {
-                "force": "${force}"
-              }
+        content: {}
     patch:
       responses:
         default:
@@ -3949,7 +3895,7 @@ paths:
           example: |-
             {
               "description": "${description}",
-              "displayname": "${displayname}",
+              "displayName": "${displayName}",
               "group": "${group}",
               "mandatory": "${mandatory}",
               "options": "${options}",
@@ -3965,7 +3911,7 @@ paths:
             example: |-
               {
                 "description": "${description}",
-                "displayname": "${displayname}",
+                "displayName": "${displayName}",
                 "group": "${group}",
                 "mandatory": "${mandatory}",
                 "options": "${options}",
@@ -3982,12 +3928,12 @@ paths:
                 type: string
                 example: |-
                   {
-                    "_createdat": 0,
-                    "_createdby": "",
+                    "_createdAt": 0,
+                    "_createdBy": "",
                     "_id": "",
                     "_type": "",
-                    "_updatedat": 0,
-                    "_updatedby": "",
+                    "_updatedAt": 0,
+                    "_updatedBy": "",
                     "description": "",
                     "status": "",
                     "title": "",
@@ -4056,12 +4002,12 @@ paths:
                 type: string
                 example: |-
                   {
-                    "_createdat": 0,
-                    "_createdby": "",
+                    "_createdAt": 0,
+                    "_createdBy": "",
                     "_id": "",
                     "_type": "",
-                    "_updatedat": 0,
-                    "_updatedby": "",
+                    "_updatedAt": 0,
+                    "_updatedBy": "",
                     "description": "",
                     "status": "",
                     "title": "",
@@ -4276,18 +4222,18 @@ paths:
                 type: string
                 example: |-
                   {
-                    "_createdat": 0,
-                    "_createdby": "",
+                    "_createdAt": 0,
+                    "_createdBy": "",
                     "_id": "",
                     "_type": "",
                     "capabilities": [],
                     "current": false,
                     "customer": "",
-                    "expiresat": 0,
+                    "expiresAt": 0,
                     "id": "",
                     "kind": "",
                     "plan": "",
-                    "validfrom": 0
+                    "validFrom": 0
                   }
       summary: Get License
       operationId: Get_License
@@ -4414,7 +4360,7 @@ paths:
           required: false
           example: |-
             {
-              "includeintimeline": "${includeintimeline}",
+              "includeInTimeline": "${includeInTimeline}",
               "message": "${message}"
             }
           schema:
@@ -4426,7 +4372,7 @@ paths:
           example:
             example: |-
               {
-                "includeintimeline": "${includeintimeline}",
+                "includeInTimeline": "${includeInTimeline}",
                 "message": "${message}"
               }
   "/api/v1/log/{logId}/attachment/{attachmentId}/download":
@@ -4527,13 +4473,13 @@ paths:
                 type: string
                 example: |-
                   {
-                    "_createdat": 0,
-                    "_createdby": "",
+                    "_createdAt": 0,
+                    "_createdBy": "",
                     "_id": "",
-                    "_updatedat": 0,
-                    "_updatedby": "",
+                    "_updatedAt": 0,
+                    "_updatedBy": "",
                     "avatar": "",
-                    "defaultorganisation": "",
+                    "defaultOrganisation": "",
                     "email": "",
                     "haskey": false,
                     "hasmfa": false,
@@ -4637,14 +4583,14 @@ paths:
           required: false
           example: |-
             {
-              "datatype": "${datatype}",
+              "dataType": "${dataType}",
               "ids": "${ids}",
-              "ignoresimilarity": "${ignoresimilarity}",
+              "ignoreSimilarity": "${ignoreSimilarity}",
               "ioc": "${ioc}",
               "message": "${message}",
               "pap": "${pap}",
               "sighted": "${sighted}",
-              "sightedat": "${sightedat}",
+              "sightedAt": "${sightedAt}",
               "tags": "${tags}",
               "tlp": "${tlp}"
             }
@@ -4657,14 +4603,14 @@ paths:
           example:
             example: |-
               {
-                "datatype": "${datatype}",
+                "dataType": "${dataType}",
                 "ids": "${ids}",
-                "ignoresimilarity": "${ignoresimilarity}",
+                "ignoreSimilarity": "${ignoreSimilarity}",
                 "ioc": "${ioc}",
                 "message": "${message}",
                 "pap": "${pap}",
                 "sighted": "${sighted}",
-                "sightedat": "${sightedat}",
+                "sightedAt": "${sightedAt}",
                 "tags": "${tags}",
                 "tlp": "${tlp}"
               }
@@ -4699,21 +4645,21 @@ paths:
                 type: string
                 example: |-
                   {
-                    "_createdat": 0,
-                    "_createdby": "",
+                    "_createdAt": 0,
+                    "_createdBy": "",
                     "_id": "",
                     "_type": "",
-                    "_updatedat": 0,
-                    "_updatedby": "",
+                    "_updatedAt": 0,
+                    "_updatedBy": "",
                     "data": "",
-                    "datatype": "",
-                    "ignoresimilarity": false,
+                    "dataType": "",
+                    "ignoreSimilarity": false,
                     "ioc": false,
                     "message": "",
                     "pap": 0,
                     "sighted": false,
-                    "sightedat": 0,
-                    "startdate": 0,
+                    "sightedAt": 0,
+                    "startDate": 0,
                     "tags": [],
                     "tlp": 0
                   }
@@ -4753,13 +4699,13 @@ paths:
           required: false
           example: |-
             {
-              "datatype": "${datatype}",
-              "ignoresimilarity": "${ignoresimilarity}",
+              "dataType": "${dataType}",
+              "ignoreSimilarity": "${ignoreSimilarity}",
               "ioc": "${ioc}",
               "message": "${message}",
               "pap": "${pap}",
               "sighted": "${sighted}",
-              "sightedat": "${sightedat}",
+              "sightedAt": "${sightedAt}",
               "tags": "${tags}",
               "tlp": "${tlp}"
             }
@@ -4772,13 +4718,13 @@ paths:
           example:
             example: |-
               {
-                "datatype": "${datatype}",
-                "ignoresimilarity": "${ignoresimilarity}",
+                "dataType": "${dataType}",
+                "ignoreSimilarity": "${ignoreSimilarity}",
                 "ioc": "${ioc}",
                 "message": "${message}",
                 "pap": "${pap}",
                 "sighted": "${sighted}",
-                "sightedat": "${sightedat}",
+                "sightedAt": "${sightedAt}",
                 "tags": "${tags}",
                 "tlp": "${tlp}"
               }
@@ -4801,26 +4747,8 @@ paths:
           required: true
           schema:
             type: string
-        - in: body
-          name: body
-          multiline: true
-          description: Generated by shuffler.io OpenAPI
-          required: false
-          example: |-
-            {
-              "organisations": "${organisations}"
-            }
-          schema:
-            type: string
       requestBody:
-        description: Generated by Shuffler.io
-        required: false
-        content:
-          example:
-            example: |-
-              {
-                "organisations": "${organisations}"
-              }
+        content: {}
     get:
       responses:
         default:
@@ -4894,19 +4822,19 @@ paths:
                 type: string
                 example: >-
                   {
-                    "_createdat": 0,
-                    "_createdby": "",
+                    "_createdAt": 0,
+                    "_createdBy": "",
                     "_id": "",
                     "_type": "",
-                    "_updatedat": 0,
-                    "_updatedby": "",
+                    "_updatedAt": 0,
+                    "_updatedBy": "",
                     "avatar": "",
                     "description": "",
                     "links": [],
                     "locked": false,
                     "name": "This field can be used to reference an organisation instead of its _id",
-                    "observablerule": "",
-                    "taskrule": ""
+                    "observableRule": "",
+                    "taskRule": ""
                   }
       summary: Create Organisation
       operationId: Create_Organisation
@@ -4921,8 +4849,8 @@ paths:
               "description": "${description}",
               "locked": "${locked}",
               "name": "${name}",
-              "observablerule": "${observablerule}",
-              "taskrule": "${taskrule}"
+              "observableRule": "${observableRule}",
+              "taskRule": "${taskRule}"
             }
           schema:
             type: string
@@ -4936,8 +4864,8 @@ paths:
                 "description": "${description}",
                 "locked": "${locked}",
                 "name": "${name}",
-                "observablerule": "${observablerule}",
-                "taskrule": "${taskrule}"
+                "observableRule": "${observableRule}",
+                "taskRule": "${taskRule}"
               }
   "/api/v1/organisation/{orgId}":
     get:
@@ -4950,19 +4878,19 @@ paths:
                 type: string
                 example: >-
                   {
-                    "_createdat": 0,
-                    "_createdby": "",
+                    "_createdAt": 0,
+                    "_createdBy": "",
                     "_id": "",
                     "_type": "",
-                    "_updatedat": 0,
-                    "_updatedby": "",
+                    "_updatedAt": 0,
+                    "_updatedBy": "",
                     "avatar": "",
                     "description": "",
                     "links": [],
                     "locked": false,
                     "name": "This field can be used to reference an organisation instead of its _id",
-                    "observablerule": "",
-                    "taskrule": ""
+                    "observableRule": "",
+                    "taskRule": ""
                   }
       summary: Get Organisation
       operationId: Get_Organisation
@@ -5004,8 +4932,8 @@ paths:
               "description": "${description}",
               "locked": "${locked}",
               "name": "${name}",
-              "observablerule": "${observablerule}",
-              "taskrule": "${taskrule}"
+              "observableRule": "${observableRule}",
+              "taskRule": "${taskRule}"
             }
           schema:
             type: string
@@ -5020,8 +4948,8 @@ paths:
                 "description": "${description}",
                 "locked": "${locked}",
                 "name": "${name}",
-                "observablerule": "${observablerule}",
-                "taskrule": "${taskrule}"
+                "observableRule": "${observableRule}",
+                "taskRule": "${taskRule}"
               }
   "/api/v1/organisation/{orgId}/avatar":
     get:
@@ -5192,7 +5120,7 @@ paths:
                     "category": "",
                     "content": "",
                     "createdat": 0,
-                    "createdby": "",
+                    "createdBy": "",
                     "id": "",
                     "order": 0,
                     "slug": "",
@@ -5359,12 +5287,12 @@ paths:
                 type: string
                 example: |-
                   {
-                    "_createdat": 0,
-                    "_createdby": "",
+                    "_createdAt": 0,
+                    "_createdBy": "",
                     "_id": "",
                     "_type": "",
-                    "_updatedat": 0,
-                    "_updatedby": "",
+                    "_updatedAt": 0,
+                    "_updatedBy": "",
                     "capecid": "",
                     "capecurl": "",
                     "datasources": [],
@@ -5372,7 +5300,7 @@ paths:
                     "description": "",
                     "detection": "",
                     "name": "",
-                    "patternid": "",
+                    "patternId": "",
                     "patterntype": "",
                     "permissionsrequired": [],
                     "platforms": [],
@@ -5441,7 +5369,7 @@ paths:
           example: |-
             {
               "description": "${description}",
-              "occurdate": "${occurdate}"
+              "occurDate": "${occurDate}"
             }
           schema:
             type: string
@@ -5453,7 +5381,7 @@ paths:
             example: |-
               {
                 "description": "${description}",
-                "occurdate": "${occurdate}"
+                "occurDate": "${occurDate}"
               }
   /api/v1/profile:
     post:
@@ -5466,12 +5394,12 @@ paths:
                 type: string
                 example: |-
                   {
-                    "_createdat": 0,
-                    "_createdby": "",
+                    "_createdAt": 0,
+                    "_createdBy": "",
                     "_id": "",
                     "_type": "",
-                    "_updatedat": 0,
-                    "_updatedby": "",
+                    "_updatedAt": 0,
+                    "_updatedBy": "",
                     "editable": false,
                     "isadmin": false,
                     "name": "",
@@ -5533,12 +5461,12 @@ paths:
                 type: string
                 example: |-
                   {
-                    "_createdat": 0,
-                    "_createdby": "",
+                    "_createdAt": 0,
+                    "_createdBy": "",
                     "_id": "",
                     "_type": "",
-                    "_updatedat": 0,
-                    "_updatedby": "",
+                    "_updatedAt": 0,
+                    "_updatedBy": "",
                     "editable": false,
                     "isadmin": false,
                     "name": "",
@@ -5608,7 +5536,7 @@ paths:
       summary: Query API
       operationId: Query_API
       description: >+
-        
+
         ### Overview
 
 
@@ -5751,39 +5679,39 @@ paths:
         Available filters:
 
 
-        - `_and`: `{"_and": [...other filters] }` 
+        - `_and`: `{"_and": [...other filters] }`
 
-        - `_or`: `{"_or": [...other filters] }` 
+        - `_or`: `{"_or": [...other filters] }`
 
-        - `_not`: `` 
+        - `_not`: ``
 
-        - `_any`: `` 
+        - `_any`: ``
 
-        - `_lt`: `{"_lt": {"_field": "<field>", "_value": <value>}` 
+        - `_lt`: `{"_lt": {"_field": "<field>", "_value": <value>}`
 
-        - `_gt`: `{"_gt": {"_field": "<field>", "_value": <value>}` 
+        - `_gt`: `{"_gt": {"_field": "<field>", "_value": <value>}`
 
         - `_lte`: `{"_lte": {"_field": "<field>", "_value": <value>}`
 
         - `_gte`: `{"_gte": {"_field": "<field>", "_value": <value>}`
 
-        - `_ne`: `{"_ne": {"_field": "<field>", "_value": <value>}` 
+        - `_ne`: `{"_ne": {"_field": "<field>", "_value": <value>}`
 
-        - `_eq`: `{"_eq": {"_field": "<field>", "_value": <value>}` 
+        - `_eq`: `{"_eq": {"_field": "<field>", "_value": <value>}`
 
         - `_is`: `{"_is": {"_field": "<field>", "_value": <value>}` - same as `_eq`
 
-        - `_startsWith`: `{"_startsWith": {"_field": "<field>", "_value": "<value>"}` 
+        - `_startsWith`: `{"_startsWith": {"_field": "<field>", "_value": "<value>"}`
 
         - `_endsWith`: `{"_endsWith": {"_field": "<field>", "_value": "<value>"}`
 
-        - `_id`: `{"_id": "~123"}` 
+        - `_id`: `{"_id": "~123"}`
 
-        - `_between`: `{"_between": {"_field": "<field>", "from": <from>, "to": <to>}}` 
+        - `_between`: `{"_between": {"_field": "<field>", "from": <from>, "to": <to>}}`
 
-        - `_in`: `{"_in": {"_field": "<field>", "_values": [<value1>, ...] }}` 
+        - `_in`: `{"_in": {"_field": "<field>", "_values": [<value1>, ...] }}`
 
-        - `_contains`: `{"_contains": "<field>"}` if an object contains this field 
+        - `_contains`: `{"_contains": "<field>"}` if an object contains this field
 
         - `_like`: `{"_like": {"_field": "<field>", "_value": "<value>"}`
 
@@ -5806,7 +5734,7 @@ paths:
 
         - Ask for extra data with the object:
           `{"_name": "page", "from": 0, "to": 30, "extraData": ["shareCount", "contributors"] }`
-          
+
           The `extraData` field of the object will contain a json object with the selected fields.
           The available `extraData` depends on the entity being requested.
 
@@ -5998,13 +5926,13 @@ paths:
             {
               "assignee": "${assignee}",
               "description": "${description}",
-              "duedate": "${duedate}",
-              "enddate": "${enddate}",
+              "dueDate": "${dueDate}",
+              "endDate": "${endDate}",
               "flag": "${flag}",
               "group": "${group}",
               "ids": "${ids}",
               "order": "${order}",
-              "startdate": "${startdate}",
+              "startDate": "${startDate}",
               "status": "${status}",
               "title": "${title}"
             }
@@ -6019,13 +5947,13 @@ paths:
               {
                 "assignee": "${assignee}",
                 "description": "${description}",
-                "duedate": "${duedate}",
-                "enddate": "${enddate}",
+                "dueDate": "${dueDate}",
+                "endDate": "${endDate}",
                 "flag": "${flag}",
                 "group": "${group}",
                 "ids": "${ids}",
                 "order": "${order}",
-                "startdate": "${startdate}",
+                "startDate": "${startDate}",
                 "status": "${status}",
                 "title": "${title}"
               }
@@ -6060,20 +5988,20 @@ paths:
                 type: string
                 example: |-
                   {
-                    "_createdat": 0,
-                    "_createdby": "",
+                    "_createdAt": 0,
+                    "_createdBy": "",
                     "_id": "",
                     "_type": "",
-                    "_updatedat": 0,
-                    "_updatedby": "",
+                    "_updatedAt": 0,
+                    "_updatedBy": "",
                     "assignee": "",
                     "description": "",
-                    "duedate": 0,
-                    "enddate": 0,
+                    "dueDate": 0,
+                    "endDate": 0,
                     "flag": false,
                     "group": "",
                     "order": 0,
-                    "startdate": 0,
+                    "startDate": 0,
                     "status": "",
                     "title": ""
                   }
@@ -6115,12 +6043,12 @@ paths:
             {
               "assignee": "${assignee}",
               "description": "${description}",
-              "duedate": "${duedate}",
-              "enddate": "${enddate}",
+              "dueDate": "${dueDate}",
+              "endDate": "${endDate}",
               "flag": "${flag}",
               "group": "${group}",
               "order": "${order}",
-              "startdate": "${startdate}",
+              "startDate": "${startDate}",
               "status": "${status}",
               "title": "${title}"
             }
@@ -6135,12 +6063,12 @@ paths:
               {
                 "assignee": "${assignee}",
                 "description": "${description}",
-                "duedate": "${duedate}",
-                "enddate": "${enddate}",
+                "dueDate": "${dueDate}",
+                "endDate": "${endDate}",
                 "flag": "${flag}",
                 "group": "${group}",
                 "order": "${order}",
-                "startdate": "${startdate}",
+                "startDate": "${startDate}",
                 "status": "${status}",
                 "title": "${title}"
               }
@@ -6254,15 +6182,15 @@ paths:
                 type: string
                 example: |-
                   {
-                    "_createdat": 0,
-                    "_createdby": "",
+                    "_createdAt": 0,
+                    "_createdBy": "",
                     "_id": "",
                     "_type": "",
-                    "_updatedat": 0,
-                    "_updatedby": "",
+                    "_updatedAt": 0,
+                    "_updatedBy": "",
                     "attachments": [],
                     "date": 0,
-                    "includeintimeline": 0,
+                    "includeInTimeline": 0,
                     "message": "",
                     "owner": ""
                   }
@@ -6282,9 +6210,9 @@ paths:
           required: false
           example: |-
             {
-              "includeintimeline": "${includeintimeline}",
+              "includeInTimeline": "${includeInTimeline}",
               "message": "${message}",
-              "startdate": "${startdate}"
+              "startDate": "${startDate}"
             }
           schema:
             type: string
@@ -6295,9 +6223,9 @@ paths:
           example:
             example: |-
               {
-                "includeintimeline": "${includeintimeline}",
+                "includeInTimeline": "${includeInTimeline}",
                 "message": "${message}",
-                "startdate": "${startdate}"
+                "startDate": "${startDate}"
               }
   "/api/v1/task/{taskId}/shares":
     delete:
@@ -6318,26 +6246,8 @@ paths:
           required: true
           schema:
             type: string
-        - in: body
-          name: body
-          multiline: true
-          description: Generated by shuffler.io OpenAPI
-          required: false
-          example: |-
-            {
-              "organisations": "${organisations}"
-            }
-          schema:
-            type: string
       requestBody:
-        description: Generated by Shuffler.io
-        required: false
-        content:
-          example:
-            example: |-
-              {
-                "organisations": "${organisations}"
-              }
+        content: {}
     get:
       responses:
         default:
@@ -6411,12 +6321,12 @@ paths:
                 type: string
                 example: |-
                   {
-                    "_createdat": 0,
-                    "_createdby": "",
+                    "_createdAt": 0,
+                    "_createdBy": "",
                     "_id": "",
                     "_type": "",
-                    "_updatedat": 0,
-                    "_updatedby": "",
+                    "_updatedAt": 0,
+                    "_updatedBy": "",
                     "description": "",
                     "namespace": "",
                     "tags": [],
@@ -6513,12 +6423,12 @@ paths:
                 type: string
                 example: |-
                   {
-                    "_createdat": 0,
-                    "_createdby": "",
+                    "_createdAt": 0,
+                    "_createdBy": "",
                     "_id": "",
                     "_type": "",
-                    "_updatedat": 0,
-                    "_updatedby": "",
+                    "_updatedAt": 0,
+                    "_updatedBy": "",
                     "description": "",
                     "namespace": "",
                     "tags": [],
@@ -6612,13 +6522,13 @@ paths:
                 type: string
                 example: |-
                   {
-                    "_createdat": 0,
-                    "_createdby": "",
+                    "_createdAt": 0,
+                    "_createdBy": "",
                     "_id": "",
-                    "_updatedat": 0,
-                    "_updatedby": "",
+                    "_updatedAt": 0,
+                    "_updatedBy": "",
                     "avatar": "",
-                    "defaultorganisation": "",
+                    "defaultOrganisation": "",
                     "email": "",
                     "haskey": false,
                     "hasmfa": false,
@@ -6678,13 +6588,13 @@ paths:
                 type: string
                 example: |-
                   {
-                    "_createdat": 0,
-                    "_createdby": "",
+                    "_createdAt": 0,
+                    "_createdBy": "",
                     "_id": "",
-                    "_updatedat": 0,
-                    "_updatedby": "",
+                    "_updatedAt": 0,
+                    "_updatedBy": "",
                     "avatar": "",
-                    "defaultorganisation": "",
+                    "defaultOrganisation": "",
                     "email": "",
                     "haskey": false,
                     "hasmfa": false,
@@ -6734,13 +6644,13 @@ paths:
                 type: string
                 example: |-
                   {
-                    "_createdat": 0,
-                    "_createdby": "",
+                    "_createdAt": 0,
+                    "_createdBy": "",
                     "_id": "",
-                    "_updatedat": 0,
-                    "_updatedby": "",
+                    "_updatedAt": 0,
+                    "_updatedBy": "",
                     "avatar": "",
-                    "defaultorganisation": "",
+                    "defaultOrganisation": "",
                     "email": "",
                     "haskey": false,
                     "hasmfa": false,
@@ -6791,7 +6701,7 @@ paths:
           example: |-
             {
               "avatar": "${avatar}",
-              "defaultorganisation": "${defaultorganisation}",
+              "defaultOrganisation": "${defaultOrganisation}",
               "email": "${email}",
               "locked": "${locked}",
               "name": "${name}",
@@ -6808,7 +6718,7 @@ paths:
             example: |-
               {
                 "avatar": "${avatar}",
-                "defaultorganisation": "${defaultorganisation}",
+                "defaultOrganisation": "${defaultOrganisation}",
                 "email": "${email}",
                 "locked": "${locked}",
                 "name": "${name}",
@@ -7005,7 +6915,7 @@ paths:
           required: false
           example: |-
             {
-              "currentpassword": "${currentpassword}",
+              "currentPassword": "${currentPassword}",
               "password": "${password}"
             }
           schema:
@@ -7017,7 +6927,7 @@ paths:
           example:
             example: |-
               {
-                "currentpassword": "${currentpassword}",
+                "currentPassword": "${currentPassword}",
                 "password": "${password}"
               }
   "/api/v1/user/{userId}/password/set":


### PR DESCRIPTION
Changed various parameter names so it matches the API's case-sensivity.

For example, creating an alert with "sourceref": "123" does not work. With "sourceRef": "123" it works fine.

https://docs.strangebee.com/thehive/api-docs/#operation/Create%20Alert